### PR TITLE
Force basic auth

### DIFF
--- a/changelogs/fragments/9-force-basic-auth.yaml
+++ b/changelogs/fragments/9-force-basic-auth.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - robot - force basic authentication against robot webservice
+  

--- a/changelogs/fragments/9-force-basic-auth.yaml
+++ b/changelogs/fragments/9-force-basic-auth.yaml
@@ -1,3 +1,3 @@
 bugfixes:
-  - robot - force basic authentication against robot webservice
+  - robot - force HTTP basic authentication to reduce number of HTTPS requests (https://github.com/ansible-collections/community.hrobot/pull/9).
   

--- a/plugins/module_utils/robot.py
+++ b/plugins/module_utils/robot.py
@@ -40,6 +40,7 @@ def plugin_open_url_json(plugin, url, method='GET', timeout=10, data=None, heade
             url,
             url_username=user,
             url_password=password,
+            force_basic_auth=True,
             data=data,
             headers=headers,
             method=method,
@@ -79,6 +80,7 @@ def fetch_url_json(module, url, method='GET', timeout=10, data=None, headers=Non
     '''
     module.params['url_username'] = module.params['hetzner_user']
     module.params['url_password'] = module.params['hetzner_password']
+    module.params['force_basic_auth'] = True
     resp, info = fetch_url(module, url, method=method, timeout=timeout, data=data, headers=headers)
     try:
         content = resp.read()


### PR DESCRIPTION
##### SUMMARY
Force basic auth, otherwise we send two request. The first without auth, which gets rejected, afterwards another request with basic auth.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
robot
