### PR TITLE
CI: Stop using ansible-galaxy collection install to install a collection

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -89,8 +89,10 @@ jobs:
       # OPTIONAL If your unit test requires Python libraries from other collections
       # Install them like this
       - name: Install collection dependencies
-        #run: ansible-galaxy collection install community.internal_test_tools -p .
-        run: git clone https://github.com/ansible-collections/community.internal_test_tools.git ansible_collections/community/internal_test_tools
+        run: git clone --depth=1 --single-branch https://github.com/ansible-collections/community.internal_test_tools.git ansible_collections/community/internal_test_tools
+        # NOTE: we're installing with git to work around Galaxy being a huge PITA (https://github.com/ansible/galaxy/issues/2429)
+        # run: ansible-galaxy collection install community.internal_test_tools -p .
+
 
       # Run the unit tests
       - name: Run unit test


### PR DESCRIPTION
##### SUMMARY
ansible/galaxy#2429 is getting to a point where it is a huge PITA. To work around it, we directly clone the corresponding git repositories.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
CI
