### PR TITLE
Rename whitelist_hos → allowlist_hos

### DIFF
--- a/changelogs/fragments/15-firewall-allowlist_hos.yml
+++ b/changelogs/fragments/15-firewall-allowlist_hos.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "firewall - rename option ``whitelist_hos`` to ``allowlist_hos``, keep old name as alias (https://github.com/ansible-collections/community.hrobot/pull/15)."

--- a/changelogs/fragments/15-firewall-allowlist_hos.yml
+++ b/changelogs/fragments/15-firewall-allowlist_hos.yml
@@ -1,2 +1,3 @@
 minor_changes:
 - "firewall - rename option ``whitelist_hos`` to ``allowlist_hos``, keep old name as alias (https://github.com/ansible-collections/community.hrobot/pull/15)."
+- "firewall, firewall_info - add return value ``allowlist_hos``, which contains the same value as ``whitelist_hos``. The old name ``whitelist_hos`` will be removed eventually (https://github.com/ansible-collections/community.hrobot/pull/15)."

--- a/plugins/modules/firewall.py
+++ b/plugins/modules/firewall.py
@@ -47,10 +47,12 @@ options:
     type: str
     default: present
     choices: [ present, absent ]
-  whitelist_hos:
+  allowlist_hos:
     description:
       - Whether Hetzner services have access.
     type: bool
+    aliases:
+      - whitelist_hos
   rules:
     description:
       - Firewall rules.
@@ -148,7 +150,7 @@ EXAMPLES = r'''
     hetzner_password: bar
     server_ip: 1.2.3.4
     state: present
-    whitelist_hos: yes
+    allowlist_hos: yes
     rules:
       input:
         - name: Allow everything to ports 20-23 from 4.3.2.1/24
@@ -314,11 +316,11 @@ def restrict_firewall_config(config):
     return result
 
 
-def update(before, after, params, name):
+def update(before, after, params, name, param_name=None):
     bv = before.get(name)
     after[name] = bv
     changed = False
-    pv = params[name]
+    pv = params[param_name or name]
     if pv is not None:
         changed = pv != bv
         if changed:
@@ -380,7 +382,7 @@ def main():
         server_ip=dict(type='str', required=True),
         port=dict(type='str', default='main', choices=['main', 'kvm']),
         state=dict(type='str', default='present', choices=['present', 'absent']),
-        whitelist_hos=dict(type='bool'),
+        allowlist_hos=dict(type='bool', aliases=['whitelist_hos']),
         rules=dict(type='dict', options=dict(
             input=dict(type='list', elements='dict', options=dict(
                 name=dict(type='str'),
@@ -445,7 +447,7 @@ def main():
     changed = False
     changed |= update(before, after, module.params, 'port')
     changed |= update(before, after, module.params, 'status')
-    changed |= update(before, after, module.params, 'whitelist_hos')
+    changed |= update(before, after, module.params, 'whitelist_hos', 'allowlist_hos')
     after['rules'] = create_default_rules_object()
     if module.params['status'] == 'active':
         for ruleset in RULES:

--- a/plugins/modules/firewall.py
+++ b/plugins/modules/firewall.py
@@ -202,9 +202,16 @@ firewall:
           I(wait_for_configured) is set to C(no) or I(timeout) to a too small value.
       type: str
       sample: active
+    allowlist_hos:
+      description:
+        - Whether Hetzner services have access.
+      type: bool
+      sample: true
+      version_added: 1.2.0
     whitelist_hos:
       description:
         - Whether Hetzner services have access.
+        - Old name of return value C(allowlist_hos), will be removed eventually.
       type: bool
       sample: true
     rules:
@@ -373,6 +380,12 @@ def create_default_rules_object():
     return rules
 
 
+def fix_naming(firewall_result):
+    firewall_result = firewall_result.copy()
+    firewall_result['allowlist_hos'] = firewall_result.get('whitelist_hos', False)
+    return firewall_result
+
+
 def firewall_configured(result, error):
     return result['firewall']['status'] != 'in process'
 
@@ -512,10 +525,10 @@ def main():
     module.exit_json(
         changed=changed,
         diff=dict(
-            before=before,
-            after=after,
+            before=fix_naming(before),
+            after=fix_naming(after),
         ),
-        firewall=full_after,
+        firewall=fix_naming(full_after),
     )
 
 

--- a/plugins/modules/firewall_info.py
+++ b/plugins/modules/firewall_info.py
@@ -98,9 +98,16 @@ firewall:
           I(wait_for_configured) is set to C(no) or I(timeout) to a too small value.
       type: str
       sample: active
+    allowlist_hos:
+      description:
+        - Whether Hetzner services have access.
+      type: bool
+      sample: true
+      version_added: 1.2.0
     whitelist_hos:
       description:
         - Whether Hetzner services have access.
+        - Old name of return value C(allowlist_hos), will be removed eventually.
       type: bool
       sample: true
     rules:
@@ -210,6 +217,7 @@ def main():
         result, error = fetch_url_json(module, url)
 
     firewall = result['firewall']
+    firewall['allowlist_hos'] = firewall.get('whitelist_hos', False)
     if not firewall.get('rules'):
         firewall['rules'] = dict()
         for ruleset in ['input']:

--- a/tests/unit/plugins/modules/test_firewall.py
+++ b/tests/unit/plugins/modules/test_firewall.py
@@ -483,11 +483,14 @@ class TestHetznerFirewall(BaseTestModule):
             .expect_url('{0}/firewall/1.2.3.4'.format(BASE_URL)),
         ])
         assert result['changed'] is False
+        assert result['diff']['before']['allowlist_hos'] is True
         assert result['diff']['before']['whitelist_hos'] is True
+        assert result['diff']['after']['allowlist_hos'] is True
         assert result['diff']['after']['whitelist_hos'] is True
         assert result['firewall']['status'] == 'active'
         assert result['firewall']['server_ip'] == '1.2.3.4'
         assert result['firewall']['server_number'] == 1
+        assert result['firewall']['allowlist_hos'] is True
         assert result['firewall']['whitelist_hos'] is True
 
     def test_allowlist_hos_changed(self, mocker):
@@ -529,11 +532,14 @@ class TestHetznerFirewall(BaseTestModule):
             .expect_form_value('whitelist_hos', 'true'),
         ])
         assert result['changed'] is True
+        assert result['diff']['before']['allowlist_hos'] is False
         assert result['diff']['before']['whitelist_hos'] is False
+        assert result['diff']['after']['allowlist_hos'] is True
         assert result['diff']['after']['whitelist_hos'] is True
         assert result['firewall']['status'] == 'active'
         assert result['firewall']['server_ip'] == '1.2.3.4'
         assert result['firewall']['server_number'] == 1
+        assert result['firewall']['allowlist_hos'] is True
         assert result['firewall']['whitelist_hos'] is True
 
     # Tests for wait_for_configured in getting status

--- a/tests/unit/plugins/modules/test_firewall.py
+++ b/tests/unit/plugins/modules/test_firewall.py
@@ -457,15 +457,15 @@ class TestHetznerFirewall(BaseTestModule):
         assert result['firewall']['server_number'] == 1
         assert result['firewall']['port'] == 'main'
 
-    # Tests for whitelist_hos
+    # Tests for allowlist_hos
 
-    def test_whitelist_hos_idempotency(self, mocker):
+    def test_allowlist_hos_idempotency(self, mocker):
         result = self.run_module_success(mocker, firewall, {
             'hetzner_user': '',
             'hetzner_password': '',
             'server_ip': '1.2.3.4',
             'state': 'present',
-            'whitelist_hos': True,
+            'allowlist_hos': True,
         }, [
             FetchUrlCall('GET', 200)
             .result_json({
@@ -490,13 +490,13 @@ class TestHetznerFirewall(BaseTestModule):
         assert result['firewall']['server_number'] == 1
         assert result['firewall']['whitelist_hos'] is True
 
-    def test_whitelist_hos_changed(self, mocker):
+    def test_allowlist_hos_changed(self, mocker):
         result = self.run_module_success(mocker, firewall, {
             'hetzner_user': '',
             'hetzner_password': '',
             'server_ip': '1.2.3.4',
             'state': 'present',
-            'whitelist_hos': True,
+            'allowlist_hos': True,
         }, [
             FetchUrlCall('GET', 200)
             .result_json({

--- a/tests/unit/plugins/modules/test_firewall_info.py
+++ b/tests/unit/plugins/modules/test_firewall_info.py
@@ -42,6 +42,7 @@ class TestHetznerFirewallInfo(BaseTestModule):
             .expect_url('{0}/firewall/1.2.3.4'.format(BASE_URL)),
         ])
         assert result['changed'] is False
+        assert result['firewall']['allowlist_hos'] is False
         assert result['firewall']['status'] == 'disabled'
         assert result['firewall']['server_ip'] == '1.2.3.4'
         assert result['firewall']['server_number'] == 1
@@ -111,7 +112,7 @@ class TestHetznerFirewallInfo(BaseTestModule):
                     'server_ip': '1.2.3.4',
                     'server_number': 1,
                     'status': 'active',
-                    'whitelist_hos': False,
+                    'whitelist_hos': True,
                     'port': 'main',
                     'rules': {
                         'input': [
@@ -144,6 +145,7 @@ class TestHetznerFirewallInfo(BaseTestModule):
             .expect_url('{0}/firewall/1.2.3.4'.format(BASE_URL)),
         ])
         assert result['changed'] is False
+        assert result['firewall']['allowlist_hos'] is True
         assert result['firewall']['status'] == 'active'
         assert result['firewall']['server_ip'] == '1.2.3.4'
         assert result['firewall']['server_number'] == 1


### PR DESCRIPTION
##### SUMMARY
My plan is to start deprecating the old names in version 2.0.0, and remove them in 3.0.0, to give users enough time to migrate to the new names. The API itself will probably stick to the old name...

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
firewall
firewall_info
