### PR TITLE
Replace deprecated v1 codecov uploader with v2

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -109,6 +109,6 @@ jobs:
         working-directory: ./ansible_collections/community/hrobot
 
       # See the reports at https://codecov.io/gh/ansible-collections/community.hrobot
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2
         with:
           fail_ci_if_error: false


### PR DESCRIPTION
##### SUMMARY
https://github.com/marketplace/actions/codecov#%EF%B8%8F--deprecration-of-v1

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
