### PR TITLE
Fix compatibility to fetch_url change in ansible-core devel

### DIFF
--- a/changelogs/fragments/fetch_url-devel.yml
+++ b/changelogs/fragments/fetch_url-devel.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Generic module HTTP support code - fix usage of ``fetch_url`` with changes in latest ansible-core ``devel`` branch (https://github.com/ansible-collections/community.hrobot/pull/28)."

--- a/changelogs/fragments/fetch_url-devel.yml
+++ b/changelogs/fragments/fetch_url-devel.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - "Generic module HTTP support code - fix usage of ``fetch_url`` with changes in latest ansible-core ``devel`` branch (https://github.com/ansible-collections/community.hrobot/pull/28)."
+  - "Generic module HTTP support code - fix usage of ``fetch_url`` with changes in latest ansible-core ``devel`` branch (https://github.com/ansible-collections/community.hrobot/pull/30)."


### PR DESCRIPTION
##### SUMMARY
There was a breaking change in ansible-core's devel branch (see https://github.com/ansible/ansible/pull/76314 for details). This makes this collection's code work with the latest version, and all older ansible-core/ansible-base/Ansible 2.9 versions.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
robot module utils