### PR TITLE
Add stable-2.13 to CI

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -28,6 +28,7 @@ jobs:
           - stable-2.10
           - stable-2.11
           - stable-2.12
+          - stable-2.13
           - devel
     runs-on: ubuntu-latest
     steps:
@@ -85,6 +86,7 @@ jobs:
           - stable-2.10
           - stable-2.11
           - stable-2.12
+          - stable-2.13
           - devel
 
     steps:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Please note that this collection does **not** support Windows targets.
 
 ## Tested with Ansible
 
-Tested with the current Ansible 2.9, ansible-base 2.10, ansible-core 2.11 and ansible-core 2.12 releases and the current development version of ansible-core. Ansible versions before 2.9.10 are not supported.
+Tested with the current Ansible 2.9, ansible-base 2.10, ansible-core 2.11, ansible-core 2.12 and ansible-core 2.13 releases and the current development version of ansible-core. Ansible versions before 2.9.10 are not supported.
 
 ## External requirements
 


### PR DESCRIPTION
##### SUMMARY
stable-2.13 has been branched. Add it to CI.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
