### PR TITLE
Add ICMP and TCP established inputs to example firewall rule

### DIFF
--- a/plugins/modules/firewall.py
+++ b/plugins/modules/firewall.py
@@ -158,7 +158,7 @@ EXAMPLES = r'''
           ip_version: ipv4
           protocol: icmp
           action: accept
-        - name: Allow responses to incoming connections
+        - name: Allow responses to incoming TCP connections
           ip_version: ipv4
           protocol: tcp
           dst_port: '32768-65535'

--- a/plugins/modules/firewall.py
+++ b/plugins/modules/firewall.py
@@ -154,7 +154,7 @@ EXAMPLES = r'''
     allowlist_hos: yes
     rules:
       input:
-        - name: Allow ICMP protocol, so you could ping your server
+        - name: Allow ICMP protocol, so you can ping your server
           ip_version: ipv4
           protocol: icmp
           action: accept

--- a/plugins/modules/firewall.py
+++ b/plugins/modules/firewall.py
@@ -158,7 +158,7 @@ EXAMPLES = r'''
           ip_version: ipv4
           protocol: icmp
           action: accept
-        - name: TCP established
+        - name: Allow responses to incoming connections
           ip_version: ipv4
           protocol: tcp
           dst_port: '32768-65535'

--- a/plugins/modules/firewall.py
+++ b/plugins/modules/firewall.py
@@ -154,7 +154,7 @@ EXAMPLES = r'''
     allowlist_hos: yes
     rules:
       input:
-        - name: ICMP
+        - name: Allow ICMP protocol, so you could ping your server
           ip_version: ipv4
           protocol: icmp
           action: accept

--- a/plugins/modules/firewall.py
+++ b/plugins/modules/firewall.py
@@ -154,6 +154,16 @@ EXAMPLES = r'''
     allowlist_hos: yes
     rules:
       input:
+        - name: ICMP
+          ip_version: ipv4
+          protocol: icmp
+          action: accept
+        - name: TCP established
+          ip_version: ipv4
+          protocol: tcp
+          dst_port: '32768-65535'
+          tcp_flags: ack
+          action: accept
         - name: Allow everything to ports 20-23 from 4.3.2.1/24
           ip_version: ipv4
           src_ip: 4.3.2.1/24


### PR DESCRIPTION
Taken from Hetzner Robot firewall SSH template example.

I've had network issues when doing an `apt update` before this change.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request