### PR TITLE
Add `robot` action group; use attributes to document module capabilities

### DIFF
--- a/changelogs/fragments/action_group.yml
+++ b/changelogs/fragments/action_group.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Added a ``community.hrobot.robot`` module defaults group / action group. Use with ``group/community.hrobot.robot`` to provide options for all Hetzner Robot modules (https://github.com/ansible-collections/community.hrobot/pull/65)."

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -4,3 +4,16 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 requires_ansible: '>=2.9.10'
+action_groups:
+  robot:
+    - boot
+    - failover_ip
+    - failover_ip_info
+    - firewall
+    - firewall_info
+    - reset
+    - reverse_dns
+    - server
+    - server_info
+    - ssh_key
+    - ssh_key_info

--- a/plugins/doc_fragments/attributes.py
+++ b/plugins/doc_fragments/attributes.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+class ModuleDocFragment(object):
+
+    # Standard documentation fragment
+    DOCUMENTATION = r'''
+attributes:
+    check_mode:
+      description: Can run in C(check_mode) and return changed status prediction without modifying target.
+    diff_mode:
+      description: Will return details on what has changed (or possibly needs changing in C(check_mode)), when in diff mode.
+    platform:
+      description: Target OS/families that can be operated against.
+      support: N/A
+'''
+
+    ACTIONGROUP_ROBOT = r'''
+attributes:
+    action_group:
+      description: Use C(group/community.hrobot.robot) in C(module_defaults) to set defaults for this module.
+      support: full
+      membership:
+        - community.hrobot.robot
+'''
+
+    CONN = r'''
+attributes:
+    become:
+      description: Is usable alongside C(become) keywords.
+    connection:
+      description: Uses the target's configured connection information to execute code on it.
+    delegation:
+      description: Can be used in conjunction with C(delegate_to) and related keywords.
+'''
+
+    FACTS = r'''
+attributes:
+    facts:
+      description: Action returns an C(ansible_facts) dictionary that will update existing host facts.
+'''
+
+    FILES = r'''
+attributes:
+    safe_file_operations:
+      description: Uses Ansbile's strict file operation functions to ensure proper permissions and avoid data corruption.
+'''
+
+    FLOW = r'''
+attributes:
+    action:
+      description: Indicates this has a corresponding action plugin so some parts of the options can be executed on the controller.
+    async:
+      description: Supports being used with the C(async) keyword.
+'''
+1

--- a/plugins/doc_fragments/attributes.py
+++ b/plugins/doc_fragments/attributes.py
@@ -12,6 +12,7 @@ class ModuleDocFragment(object):
 
     # Standard documentation fragment
     DOCUMENTATION = r'''
+options: {}
 attributes:
     check_mode:
       description: Can run in C(check_mode) and return changed status prediction without modifying target.
@@ -23,6 +24,7 @@ attributes:
 '''
 
     ACTIONGROUP_ROBOT = r'''
+options: {}
 attributes:
     action_group:
       description: Use C(group/community.hrobot.robot) in C(module_defaults) to set defaults for this module.
@@ -32,6 +34,7 @@ attributes:
 '''
 
     CONN = r'''
+options: {}
 attributes:
     become:
       description: Is usable alongside C(become) keywords.
@@ -42,22 +45,24 @@ attributes:
 '''
 
     FACTS = r'''
+options: {}
 attributes:
     facts:
       description: Action returns an C(ansible_facts) dictionary that will update existing host facts.
 '''
 
     FILES = r'''
+options: {}
 attributes:
     safe_file_operations:
       description: Uses Ansbile's strict file operation functions to ensure proper permissions and avoid data corruption.
 '''
 
     FLOW = r'''
+options: {}
 attributes:
     action:
       description: Indicates this has a corresponding action plugin so some parts of the options can be executed on the controller.
     async:
       description: Supports being used with the C(async) keyword.
 '''
-1

--- a/plugins/doc_fragments/attributes.py
+++ b/plugins/doc_fragments/attributes.py
@@ -20,6 +20,20 @@ attributes:
       description: Will return details on what has changed (or possibly needs changing in C(check_mode)), when in diff mode.
 '''
 
+    # Should be used together with the standard fragment
+    INFO_MODULE = r'''
+options: {}
+attributes:
+    check_mode:
+      support: full
+      details:
+        - This action does not modify state.
+    diff_mode:
+      support: N/A
+      details:
+        - This action does not modify state.
+'''
+
     ACTIONGROUP_ROBOT = r'''
 options: {}
 attributes:
@@ -46,6 +60,22 @@ options: {}
 attributes:
     facts:
       description: Action returns an C(ansible_facts) dictionary that will update existing host facts.
+'''
+
+    # Should be used together with the standard fragment and the FACTS fragment
+    FACTS_MODULE = r'''
+options: {}
+attributes:
+    check_mode:
+      support: full
+      details:
+        - This action does not modify state.
+    diff_mode:
+      support: N/A
+      details:
+        - This action does not modify state.
+    facts:
+      support: full
 '''
 
     FILES = r'''

--- a/plugins/doc_fragments/attributes.py
+++ b/plugins/doc_fragments/attributes.py
@@ -18,9 +18,6 @@ attributes:
       description: Can run in C(check_mode) and return changed status prediction without modifying target.
     diff_mode:
       description: Will return details on what has changed (or possibly needs changing in C(check_mode)), when in diff mode.
-    platform:
-      description: Target OS/families that can be operated against.
-      support: N/A
 '''
 
     ACTIONGROUP_ROBOT = r'''
@@ -55,7 +52,7 @@ attributes:
 options: {}
 attributes:
     safe_file_operations:
-      description: Uses Ansbile's strict file operation functions to ensure proper permissions and avoid data corruption.
+      description: Uses Ansible's strict file operation functions to ensure proper permissions and avoid data corruption.
 '''
 
     FLOW = r'''

--- a/plugins/modules/boot.py
+++ b/plugins/modules/boot.py
@@ -29,12 +29,12 @@ extends_documentation_fragment:
   - community.hrobot.attributes.actiongroup_robot
 
 attributes:
-    action_group:
-        version_added: 1.6.0
-    check_mode:
-        support: full
-    diff_mode:
-        support: none
+  action_group:
+    version_added: 1.6.0
+  check_mode:
+    support: full
+  diff_mode:
+    support: none
 
 options:
   server_number:

--- a/plugins/modules/boot.py
+++ b/plugins/modules/boot.py
@@ -25,11 +25,16 @@ seealso:
     description: Query information on SSH keys
 extends_documentation_fragment:
   - community.hrobot.robot
+  - community.hrobot.attributes
   - community.hrobot.attributes.actiongroup_robot
 
 attributes:
     action_group:
         version_added: 1.6.0
+    check_mode:
+        support: full
+    diff_mode:
+        support: none
 
 options:
   server_number:

--- a/plugins/modules/boot.py
+++ b/plugins/modules/boot.py
@@ -25,6 +25,11 @@ seealso:
     description: Query information on SSH keys
 extends_documentation_fragment:
   - community.hrobot.robot
+  - community.hrobot.attributes.actiongroup_robot
+
+attributes:
+    action_group:
+        version_added: 1.6.0
 
 options:
   server_number:

--- a/plugins/modules/failover_ip.py
+++ b/plugins/modules/failover_ip.py
@@ -25,11 +25,16 @@ seealso:
     description: Retrieve information on failover IPs.
 extends_documentation_fragment:
   - community.hrobot.robot
+  - community.hrobot.attributes
   - community.hrobot.attributes.actiongroup_robot
 
 attributes:
     action_group:
         version_added: 1.6.0
+    check_mode:
+        support: full
+    diff_mode:
+        support: full
 
 options:
   failover_ip:

--- a/plugins/modules/failover_ip.py
+++ b/plugins/modules/failover_ip.py
@@ -29,12 +29,12 @@ extends_documentation_fragment:
   - community.hrobot.attributes.actiongroup_robot
 
 attributes:
-    action_group:
-        version_added: 1.6.0
-    check_mode:
-        support: full
-    diff_mode:
-        support: full
+  action_group:
+    version_added: 1.6.0
+  check_mode:
+    support: full
+  diff_mode:
+    support: full
 
 options:
   failover_ip:

--- a/plugins/modules/failover_ip.py
+++ b/plugins/modules/failover_ip.py
@@ -24,7 +24,12 @@ seealso:
   - module: community.hrobot.failover_ip_info
     description: Retrieve information on failover IPs.
 extends_documentation_fragment:
-- community.hrobot.robot
+  - community.hrobot.robot
+  - community.hrobot.attributes.actiongroup_robot
+
+attributes:
+    action_group:
+        version_added: 1.6.0
 
 options:
   failover_ip:

--- a/plugins/modules/failover_ip_info.py
+++ b/plugins/modules/failover_ip_info.py
@@ -33,8 +33,12 @@ attributes:
         version_added: 1.6.0
     check_mode:
         support: full
+        details:
+          - This action does not modify state.
     diff_mode:
-        support: full
+        support: N/A
+        details:
+          - This action does not modify state.
 
 options:
   failover_ip:

--- a/plugins/modules/failover_ip_info.py
+++ b/plugins/modules/failover_ip_info.py
@@ -25,11 +25,16 @@ seealso:
     description: Manage failover IPs.
 extends_documentation_fragment:
   - community.hrobot.robot
+  - community.hrobot.attributes
   - community.hrobot.attributes.actiongroup_robot
 
 attributes:
     action_group:
         version_added: 1.6.0
+    check_mode:
+        support: full
+    diff_mode:
+        support: full
 
 options:
   failover_ip:

--- a/plugins/modules/failover_ip_info.py
+++ b/plugins/modules/failover_ip_info.py
@@ -27,18 +27,11 @@ extends_documentation_fragment:
   - community.hrobot.robot
   - community.hrobot.attributes
   - community.hrobot.attributes.actiongroup_robot
+  - community.hrobot.attributes.info_module
 
 attributes:
-    action_group:
-        version_added: 1.6.0
-    check_mode:
-        support: full
-        details:
-          - This action does not modify state.
-    diff_mode:
-        support: N/A
-        details:
-          - This action does not modify state.
+  action_group:
+    version_added: 1.6.0
 
 options:
   failover_ip:

--- a/plugins/modules/failover_ip_info.py
+++ b/plugins/modules/failover_ip_info.py
@@ -24,7 +24,12 @@ seealso:
   - module: community.hrobot.failover_ip
     description: Manage failover IPs.
 extends_documentation_fragment:
-- community.hrobot.robot
+  - community.hrobot.robot
+  - community.hrobot.attributes.actiongroup_robot
+
+attributes:
+    action_group:
+        version_added: 1.6.0
 
 options:
   failover_ip:

--- a/plugins/modules/firewall.py
+++ b/plugins/modules/firewall.py
@@ -29,11 +29,16 @@ seealso:
     description: Retrieve information on firewall configuration.
 extends_documentation_fragment:
   - community.hrobot.robot
+  - community.hrobot.attributes
   - community.hrobot.attributes.actiongroup_robot
 
 attributes:
     action_group:
         version_added: 1.6.0
+    check_mode:
+        support: full
+    diff_mode:
+        support: full
 
 options:
   server_ip:

--- a/plugins/modules/firewall.py
+++ b/plugins/modules/firewall.py
@@ -28,7 +28,12 @@ seealso:
   - module: community.hrobot.firewall_info
     description: Retrieve information on firewall configuration.
 extends_documentation_fragment:
-- community.hrobot.robot
+  - community.hrobot.robot
+  - community.hrobot.attributes.actiongroup_robot
+
+attributes:
+    action_group:
+        version_added: 1.6.0
 
 options:
   server_ip:

--- a/plugins/modules/firewall.py
+++ b/plugins/modules/firewall.py
@@ -33,12 +33,12 @@ extends_documentation_fragment:
   - community.hrobot.attributes.actiongroup_robot
 
 attributes:
-    action_group:
-        version_added: 1.6.0
-    check_mode:
-        support: full
-    diff_mode:
-        support: full
+  action_group:
+    version_added: 1.6.0
+  check_mode:
+    support: full
+  diff_mode:
+    support: full
 
 options:
   server_ip:

--- a/plugins/modules/firewall_info.py
+++ b/plugins/modules/firewall_info.py
@@ -25,11 +25,16 @@ seealso:
     description: Configure firewall.
 extends_documentation_fragment:
   - community.hrobot.robot
+  - community.hrobot.attributes
   - community.hrobot.attributes.actiongroup_robot
 
 attributes:
     action_group:
         version_added: 1.6.0
+    check_mode:
+        support: full
+    diff_mode:
+        support: full
 
 options:
   server_ip:

--- a/plugins/modules/firewall_info.py
+++ b/plugins/modules/firewall_info.py
@@ -27,18 +27,11 @@ extends_documentation_fragment:
   - community.hrobot.robot
   - community.hrobot.attributes
   - community.hrobot.attributes.actiongroup_robot
+  - community.hrobot.attributes.info_module
 
 attributes:
-    action_group:
-        version_added: 1.6.0
-    check_mode:
-        support: full
-        details:
-          - This action does not modify state.
-    diff_mode:
-        support: N/A
-        details:
-          - This action does not modify state.
+  action_group:
+    version_added: 1.6.0
 
 options:
   server_ip:

--- a/plugins/modules/firewall_info.py
+++ b/plugins/modules/firewall_info.py
@@ -33,8 +33,12 @@ attributes:
         version_added: 1.6.0
     check_mode:
         support: full
+        details:
+          - This action does not modify state.
     diff_mode:
-        support: full
+        support: N/A
+        details:
+          - This action does not modify state.
 
 options:
   server_ip:

--- a/plugins/modules/firewall_info.py
+++ b/plugins/modules/firewall_info.py
@@ -24,7 +24,12 @@ seealso:
   - module: community.hrobot.firewall
     description: Configure firewall.
 extends_documentation_fragment:
-- community.hrobot.robot
+  - community.hrobot.robot
+  - community.hrobot.attributes.actiongroup_robot
+
+attributes:
+    action_group:
+        version_added: 1.6.0
 
 options:
   server_ip:

--- a/plugins/modules/reset.py
+++ b/plugins/modules/reset.py
@@ -20,6 +20,11 @@ description:
   - Reset a dedicated server with a software or hardware reset, or by requesting a manual reset.
 extends_documentation_fragment:
   - community.hrobot.robot
+  - community.hrobot.attributes.actiongroup_robot
+
+attributes:
+    action_group:
+        version_added: 1.6.0
 
 options:
   server_number:

--- a/plugins/modules/reset.py
+++ b/plugins/modules/reset.py
@@ -20,11 +20,16 @@ description:
   - Reset a dedicated server with a software or hardware reset, or by requesting a manual reset.
 extends_documentation_fragment:
   - community.hrobot.robot
+  - community.hrobot.attributes
   - community.hrobot.attributes.actiongroup_robot
 
 attributes:
     action_group:
         version_added: 1.6.0
+    check_mode:
+        support: full
+    diff_mode:
+        support: none
 
 options:
   server_number:

--- a/plugins/modules/reset.py
+++ b/plugins/modules/reset.py
@@ -24,12 +24,12 @@ extends_documentation_fragment:
   - community.hrobot.attributes.actiongroup_robot
 
 attributes:
-    action_group:
-        version_added: 1.6.0
-    check_mode:
-        support: full
-    diff_mode:
-        support: none
+  action_group:
+    version_added: 1.6.0
+  check_mode:
+    support: full
+  diff_mode:
+    support: none
 
 options:
   server_number:

--- a/plugins/modules/reverse_dns.py
+++ b/plugins/modules/reverse_dns.py
@@ -29,12 +29,12 @@ notes:
     in this case.
 
 attributes:
-    action_group:
-        version_added: 1.6.0
-    check_mode:
-        support: full
-    diff_mode:
-        support: none
+  action_group:
+    version_added: 1.6.0
+  check_mode:
+    support: full
+  diff_mode:
+    support: none
 
 options:
   ip:

--- a/plugins/modules/reverse_dns.py
+++ b/plugins/modules/reverse_dns.py
@@ -20,6 +20,7 @@ description:
   - Allows to set, update or remove a reverse DNS entry for an IP address.
 extends_documentation_fragment:
   - community.hrobot.robot
+  - community.hrobot.attributes
   - community.hrobot.attributes.actiongroup_robot
 notes:
   - For the main IPv4 address of a server, deleting it actually sets it to a default hostname like
@@ -30,6 +31,10 @@ notes:
 attributes:
     action_group:
         version_added: 1.6.0
+    check_mode:
+        support: full
+    diff_mode:
+        support: none
 
 options:
   ip:

--- a/plugins/modules/reverse_dns.py
+++ b/plugins/modules/reverse_dns.py
@@ -20,11 +20,16 @@ description:
   - Allows to set, update or remove a reverse DNS entry for an IP address.
 extends_documentation_fragment:
   - community.hrobot.robot
+  - community.hrobot.attributes.actiongroup_robot
 notes:
   - For the main IPv4 address of a server, deleting it actually sets it to a default hostname like
     C(static.X.Y.Z.W.clients.your-server.de). This substitution (delete is replaced by changing to
     this value) is done automatically by the API and results in the module not being idempotent
     in this case.
+
+attributes:
+    action_group:
+        version_added: 1.6.0
 
 options:
   ip:

--- a/plugins/modules/server.py
+++ b/plugins/modules/server.py
@@ -21,11 +21,16 @@ description:
   - Right now the API only supports updating the server's name.
 extends_documentation_fragment:
   - community.hrobot.robot
+  - community.hrobot.attributes
   - community.hrobot.attributes.actiongroup_robot
 
 attributes:
     action_group:
         version_added: 1.6.0
+    check_mode:
+        support: full
+    diff_mode:
+        support: none
 
 options:
   server_number:

--- a/plugins/modules/server.py
+++ b/plugins/modules/server.py
@@ -21,6 +21,11 @@ description:
   - Right now the API only supports updating the server's name.
 extends_documentation_fragment:
   - community.hrobot.robot
+  - community.hrobot.attributes.actiongroup_robot
+
+attributes:
+    action_group:
+        version_added: 1.6.0
 
 options:
   server_number:

--- a/plugins/modules/server.py
+++ b/plugins/modules/server.py
@@ -25,12 +25,12 @@ extends_documentation_fragment:
   - community.hrobot.attributes.actiongroup_robot
 
 attributes:
-    action_group:
-        version_added: 1.6.0
-    check_mode:
-        support: full
-    diff_mode:
-        support: none
+  action_group:
+    version_added: 1.6.0
+  check_mode:
+    support: full
+  diff_mode:
+    support: none
 
 options:
   server_number:

--- a/plugins/modules/server_info.py
+++ b/plugins/modules/server_info.py
@@ -20,11 +20,16 @@ description:
   - Query information on one or more servers.
 extends_documentation_fragment:
   - community.hrobot.robot
+  - community.hrobot.attributes
   - community.hrobot.attributes.actiongroup_robot
 
 attributes:
     action_group:
         version_added: 1.6.0
+    check_mode:
+        support: full
+    diff_mode:
+        support: full
 
 options:
   server_number:

--- a/plugins/modules/server_info.py
+++ b/plugins/modules/server_info.py
@@ -20,6 +20,11 @@ description:
   - Query information on one or more servers.
 extends_documentation_fragment:
   - community.hrobot.robot
+  - community.hrobot.attributes.actiongroup_robot
+
+attributes:
+    action_group:
+        version_added: 1.6.0
 
 options:
   server_number:

--- a/plugins/modules/server_info.py
+++ b/plugins/modules/server_info.py
@@ -22,18 +22,11 @@ extends_documentation_fragment:
   - community.hrobot.robot
   - community.hrobot.attributes
   - community.hrobot.attributes.actiongroup_robot
+  - community.hrobot.attributes.info_module
 
 attributes:
-    action_group:
-        version_added: 1.6.0
-    check_mode:
-        support: full
-        details:
-          - This action does not modify state.
-    diff_mode:
-        support: N/A
-        details:
-          - This action does not modify state.
+  action_group:
+    version_added: 1.6.0
 
 options:
   server_number:

--- a/plugins/modules/server_info.py
+++ b/plugins/modules/server_info.py
@@ -28,8 +28,12 @@ attributes:
         version_added: 1.6.0
     check_mode:
         support: full
+        details:
+          - This action does not modify state.
     diff_mode:
-        support: full
+        support: N/A
+        details:
+          - This action does not modify state.
 
 options:
   server_number:

--- a/plugins/modules/ssh_key.py
+++ b/plugins/modules/ssh_key.py
@@ -23,6 +23,11 @@ seealso:
     description: Query information on SSH keys
 extends_documentation_fragment:
   - community.hrobot.robot
+  - community.hrobot.attributes.actiongroup_robot
+
+attributes:
+    action_group:
+        version_added: 1.6.0
 
 options:
     state:

--- a/plugins/modules/ssh_key.py
+++ b/plugins/modules/ssh_key.py
@@ -27,12 +27,12 @@ extends_documentation_fragment:
   - community.hrobot.attributes.actiongroup_robot
 
 attributes:
-    action_group:
-        version_added: 1.6.0
-    check_mode:
-        support: full
-    diff_mode:
-        support: none
+  action_group:
+    version_added: 1.6.0
+  check_mode:
+    support: full
+  diff_mode:
+    support: none
 
 options:
     state:

--- a/plugins/modules/ssh_key.py
+++ b/plugins/modules/ssh_key.py
@@ -23,11 +23,16 @@ seealso:
     description: Query information on SSH keys
 extends_documentation_fragment:
   - community.hrobot.robot
+  - community.hrobot.attributes
   - community.hrobot.attributes.actiongroup_robot
 
 attributes:
     action_group:
         version_added: 1.6.0
+    check_mode:
+        support: full
+    diff_mode:
+        support: none
 
 options:
     state:

--- a/plugins/modules/ssh_key_info.py
+++ b/plugins/modules/ssh_key_info.py
@@ -25,17 +25,10 @@ extends_documentation_fragment:
   - community.hrobot.robot
   - community.hrobot.attributes
   - community.hrobot.attributes.actiongroup_robot
+  - community.hrobot.attributes.info_module
 attributes:
-    action_group:
-        version_added: 1.6.0
-    check_mode:
-        support: full
-        details:
-          - This action does not modify state.
-    diff_mode:
-        support: N/A
-        details:
-          - This action does not modify state.
+  action_group:
+    version_added: 1.6.0
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/ssh_key_info.py
+++ b/plugins/modules/ssh_key_info.py
@@ -23,6 +23,10 @@ seealso:
     description: Add, remove or update SSH key
 extends_documentation_fragment:
   - community.hrobot.robot
+  - community.hrobot.attributes.actiongroup_robot
+attributes:
+    action_group:
+        version_added: 1.6.0
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/ssh_key_info.py
+++ b/plugins/modules/ssh_key_info.py
@@ -23,10 +23,15 @@ seealso:
     description: Add, remove or update SSH key
 extends_documentation_fragment:
   - community.hrobot.robot
+  - community.hrobot.attributes
   - community.hrobot.attributes.actiongroup_robot
 attributes:
     action_group:
         version_added: 1.6.0
+    check_mode:
+        support: full
+    diff_mode:
+        support: full
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/ssh_key_info.py
+++ b/plugins/modules/ssh_key_info.py
@@ -30,8 +30,12 @@ attributes:
         version_added: 1.6.0
     check_mode:
         support: full
+        details:
+          - This action does not modify state.
     diff_mode:
-        support: full
+        support: N/A
+        details:
+          - This action does not modify state.
 '''
 
 EXAMPLES = r'''


### PR DESCRIPTION
##### SUMMARY
Add `community.hrobot.robot` action group.

Uses attributes to document module capabilities.

##### ISSUE TYPE
- Feature Pull Request
- Docs Pull Request

##### COMPONENT NAME
all modules
