### PR TITLE
Add server_number options to firewall modules

### DIFF
--- a/changelogs/fragments/77-firewall-server_number.yml
+++ b/changelogs/fragments/77-firewall-server_number.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "firewall, firewall_info - add ``server_number`` option that can be used instead of ``server_ip`` to identify the server. Hetzner deprecated configuring the firewall by ``server_ip``, so using ``server_ip`` will stop at some point in the future (https://github.com/ansible-collections/community.hrobot/pull/77)."

--- a/tests/unit/plugins/modules/test_firewall.py
+++ b/tests/unit/plugins/modules/test_firewall.py
@@ -111,7 +111,7 @@ class TestHetznerFirewall(BaseTestModule):
         result = self.run_module_success(mocker, firewall, {
             'hetzner_user': '',
             'hetzner_password': '',
-            'server_ip': '1.2.3.4',
+            'server_number': 4321,
             'state': 'absent',
         }, [
             FetchUrlCall('GET', 200)
@@ -119,7 +119,7 @@ class TestHetznerFirewall(BaseTestModule):
                 'firewall': {
                     'filter_ipv6': False,
                     'server_ip': '1.2.3.4',
-                    'server_number': 1,
+                    'server_number': 4321,
                     'status': 'active',
                     'whitelist_hos': True,
                     'port': 'main',
@@ -129,13 +129,13 @@ class TestHetznerFirewall(BaseTestModule):
                     },
                 },
             })
-            .expect_url('{0}/firewall/1.2.3.4'.format(BASE_URL)),
+            .expect_url('{0}/firewall/4321'.format(BASE_URL)),
             FetchUrlCall('POST', 200)
             .result_json({
                 'firewall': {
                     'filter_ipv6': False,
                     'server_ip': '1.2.3.4',
-                    'server_number': 1,
+                    'server_number': 4321,
                     'status': 'disabled',
                     'whitelist_hos': False,
                     'port': 'main',
@@ -145,7 +145,7 @@ class TestHetznerFirewall(BaseTestModule):
                     },
                 },
             })
-            .expect_url('{0}/firewall/1.2.3.4'.format(BASE_URL))
+            .expect_url('{0}/firewall/4321'.format(BASE_URL))
             .expect_form_value('status', 'disabled'),
         ])
         assert result['changed'] is True
@@ -153,7 +153,7 @@ class TestHetznerFirewall(BaseTestModule):
         assert result['diff']['after']['status'] == 'disabled'
         assert result['firewall']['status'] == 'disabled'
         assert result['firewall']['server_ip'] == '1.2.3.4'
-        assert result['firewall']['server_number'] == 1
+        assert result['firewall']['server_number'] == 4321
 
     def test_absent_changed_no_rules(self, mocker):
         result = self.run_module_success(mocker, firewall, {

--- a/tests/unit/plugins/modules/test_firewall_info.py
+++ b/tests/unit/plugins/modules/test_firewall_info.py
@@ -25,7 +25,7 @@ class TestHetznerFirewallInfo(BaseTestModule):
         result = self.run_module_success(mocker, firewall_info, {
             'hetzner_user': 'test',
             'hetzner_password': 'hunter2',
-            'server_ip': '1.2.3.4',
+            'server_number': 1,
         }, [
             FetchUrlCall('GET', 200)
             .expect_basic_auth('test', 'hunter2')
@@ -44,7 +44,7 @@ class TestHetznerFirewallInfo(BaseTestModule):
                     },
                 },
             })
-            .expect_url('{0}/firewall/1.2.3.4'.format(BASE_URL)),
+            .expect_url('{0}/firewall/1'.format(BASE_URL)),
         ])
         assert result['changed'] is False
         assert result['firewall']['filter_ipv6'] is False
@@ -194,7 +194,7 @@ class TestHetznerFirewallInfo(BaseTestModule):
         result = self.run_module_success(mocker, firewall_info, {
             'hetzner_user': '',
             'hetzner_password': '',
-            'server_ip': '1.2.3.4',
+            'server_number': 123,
             'wait_for_configured': True,
         }, [
             FetchUrlCall('GET', 200)
@@ -202,7 +202,7 @@ class TestHetznerFirewallInfo(BaseTestModule):
                 'firewall': {
                     'filter_ipv6': True,
                     'server_ip': '1.2.3.4',
-                    'server_number': 1,
+                    'server_number': 123,
                     'status': 'in process',
                     'whitelist_hos': False,
                     'port': 'main',
@@ -212,13 +212,13 @@ class TestHetznerFirewallInfo(BaseTestModule):
                     },
                 },
             })
-            .expect_url('{0}/firewall/1.2.3.4'.format(BASE_URL)),
+            .expect_url('{0}/firewall/123'.format(BASE_URL)),
             FetchUrlCall('GET', 200)
             .result_json({
                 'firewall': {
                     'filter_ipv6': True,
                     'server_ip': '1.2.3.4',
-                    'server_number': 1,
+                    'server_number': 123,
                     'status': 'in process',
                     'whitelist_hos': False,
                     'port': 'main',
@@ -228,13 +228,13 @@ class TestHetznerFirewallInfo(BaseTestModule):
                     },
                 },
             })
-            .expect_url('{0}/firewall/1.2.3.4'.format(BASE_URL)),
+            .expect_url('{0}/firewall/123'.format(BASE_URL)),
             FetchUrlCall('GET', 200)
             .result_json({
                 'firewall': {
                     'filter_ipv6': False,
                     'server_ip': '1.2.3.4',
-                    'server_number': 1,
+                    'server_number': 123,
                     'status': 'active',
                     'whitelist_hos': True,
                     'port': 'main',
@@ -244,7 +244,7 @@ class TestHetznerFirewallInfo(BaseTestModule):
                     },
                 },
             })
-            .expect_url('{0}/firewall/1.2.3.4'.format(BASE_URL)),
+            .expect_url('{0}/firewall/123'.format(BASE_URL)),
         ])
         assert result['changed'] is False
         assert result['firewall']['filter_ipv6'] is False
@@ -252,7 +252,7 @@ class TestHetznerFirewallInfo(BaseTestModule):
         assert result['firewall']['allowlist_hos'] is True
         assert result['firewall']['status'] == 'active'
         assert result['firewall']['server_ip'] == '1.2.3.4'
-        assert result['firewall']['server_number'] == 1
+        assert result['firewall']['server_number'] == 123
 
     def test_wait_get_timeout(self, mocker):
         mocker.patch('time.sleep', lambda duration: None)


### PR DESCRIPTION
##### SUMMARY
Identifying the server for firewalls by server main IP is deprecated (https://robot.hetzner.com/doc/webservice/en.html#get-firewall-server-id at the very bottom). This PR adds a `server_number` option that allows to identify the server by its identifier.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
firewall
firewall_info
