### PR TITLE
Do extra docs validation; explicitly disallow semantic markup in docs

### DIFF
--- a/plugins/modules/boot.py
+++ b/plugins/modules/boot.py
@@ -18,6 +18,7 @@ author:
   - Felix Fontein (@felixfontein)
 description:
   - Set the boot configuration for a dedicated server.
+  - M(foo).
 seealso:
   - module: community.hrobot.ssh_key
     description: Add, remove or update SSH key

--- a/plugins/modules/boot.py
+++ b/plugins/modules/boot.py
@@ -18,7 +18,6 @@ author:
   - Felix Fontein (@felixfontein)
 description:
   - Set the boot configuration for a dedicated server.
-  - M(foo).
 seealso:
   - module: community.hrobot.ssh_key
     description: Add, remove or update SSH key

--- a/tests/sanity/extra/extra-docs.json
+++ b/tests/sanity/extra/extra-docs.json
@@ -1,7 +1,9 @@
 {
     "include_symlinks": false,
     "prefixes": [
-        "docs/docsite/"
+        "docs/docsite/",
+        "plugins/",
+        "roles/"
     ],
     "output": "path-line-column-message",
     "requirements": [

--- a/tests/sanity/extra/extra-docs.json
+++ b/tests/sanity/extra/extra-docs.json
@@ -5,6 +5,7 @@
     ],
     "output": "path-line-column-message",
     "requirements": [
+        "ansible-core",
         "antsibull-docs"
     ]
 }

--- a/tests/sanity/extra/extra-docs.py
+++ b/tests/sanity/extra/extra-docs.py
@@ -6,7 +6,6 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import os
 import sys
 import subprocess
 

--- a/tests/sanity/extra/extra-docs.py
+++ b/tests/sanity/extra/extra-docs.py
@@ -14,8 +14,8 @@ import subprocess
 def main():
     """Main entry point."""
     env = os.environ.copy()
-    suffix = f':{env["ANSIBLE_COLLECTIONS_PATH"]}' if 'ANSIBLE_COLLECTIONS_PATH' in env else ''
-    env['ANSIBLE_COLLECTIONS_PATH'] = f'{os.path.dirname(os.path.dirname(os.path.dirname(os.getcwd())))}{suffix}'
+    suffix = ':{env}'.format(env=env["ANSIBLE_COLLECTIONS_PATH"]) if 'ANSIBLE_COLLECTIONS_PATH' in env else ''
+    env['ANSIBLE_COLLECTIONS_PATH'] = '{root}{suffix}'.format(root=os.path.dirname(os.path.dirname(os.path.dirname(os.getcwd()))), suffix=suffix)
     p = subprocess.run(
         ['antsibull-docs', 'lint-collection-docs', '--plugin-docs', '--disallow-semantic-markup', '--skip-rstcheck', '.'],
         env=env,

--- a/tests/sanity/extra/extra-docs.py
+++ b/tests/sanity/extra/extra-docs.py
@@ -15,7 +15,7 @@ def main():
     """Main entry point."""
     if not os.path.isdir(os.path.join('docs', 'docsite')):
         return
-    p = subprocess.run(['antsibull-docs', 'lint-collection-docs', '.'], check=False)
+    p = subprocess.run(['antsibull-docs', 'lint-collection-docs', '--plugin-docs', '--disallow-semantic-markup', '--skip-rstcheck', '.'], check=False)
     if p.returncode not in (0, 3):
         print('{0}:0:0: unexpected return code {1}'.format(sys.argv[0], p.returncode))
 

--- a/tests/sanity/extra/extra-docs.py
+++ b/tests/sanity/extra/extra-docs.py
@@ -6,13 +6,21 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import os
 import sys
 import subprocess
 
 
 def main():
     """Main entry point."""
-    p = subprocess.run(['antsibull-docs', 'lint-collection-docs', '--plugin-docs', '--disallow-semantic-markup', '--skip-rstcheck', '.'], check=False)
+    env = os.environ.copy()
+    suffix = f':{env["ANSIBLE_COLLECTIONS_PATH"]}' if 'ANSIBLE_COLLECTIONS_PATH' in env else ''
+    env['ANSIBLE_COLLECTIONS_PATH'] = f'{os.path.dirname(os.path.dirname(os.path.dirname(os.getcwd())))}{suffix}'
+    p = subprocess.run(
+        ['antsibull-docs', 'lint-collection-docs', '--plugin-docs', '--disallow-semantic-markup', '--skip-rstcheck', '.'],
+        env=env,
+        check=False,
+    )
     if p.returncode not in (0, 3):
         print('{0}:0:0: unexpected return code {1}'.format(sys.argv[0], p.returncode))
 

--- a/tests/sanity/extra/extra-docs.py
+++ b/tests/sanity/extra/extra-docs.py
@@ -13,8 +13,6 @@ import subprocess
 
 def main():
     """Main entry point."""
-    if not os.path.isdir(os.path.join('docs', 'docsite')):
-        return
     p = subprocess.run(['antsibull-docs', 'lint-collection-docs', '--plugin-docs', '--disallow-semantic-markup', '--skip-rstcheck', '.'], check=False)
     if p.returncode not in (0, 3):
         print('{0}:0:0: unexpected return code {1}'.format(sys.argv[0], p.returncode))


### PR DESCRIPTION
##### SUMMARY
Use `antsibull-docs lint-collection-docs --plugin-docs` to do additional documentation validation. This is important if the docs build workflow is no longer there (#6344).

This also ensures that no semantic markup is used. This should be changed once the last Ansible 6.x.y release is out containing this collection; from then on we can (relatively) safely start using semantic markup without defacing the Ansible 7 (or before) documentation.

##### ISSUE TYPE
- Docs Pull Request
- Test Pull Request

##### COMPONENT NAME
CI
