### PR TITLE
CI: Bump hard-coded Python versions to 3.11

### DIFF
--- a/.github/workflows/extra-tests.yml
+++ b/.github/workflows/extra-tests.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install ansible-core
         run: pip install https://github.com/ansible/ansible/archive/devel.tar.gz --disable-pip-version-check

--- a/.github/workflows/import-galaxy.yml
+++ b/.github/workflows/import-galaxy.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install ansible-core
         run: pip install https://github.com/ansible/ansible/archive/devel.tar.gz --disable-pip-version-check
@@ -71,7 +71,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install ansible-core
         run: pip install https://github.com/ansible/ansible/archive/devel.tar.gz --disable-pip-version-check


### PR DESCRIPTION
##### SUMMARY
Bump hard-coded Python versions in workflows from 3.10 to 3.11.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
