### PR TITLE
Improve error reporting and firewall docs

### DIFF
--- a/changelogs/fragments/89-firewall.yml
+++ b/changelogs/fragments/89-firewall.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Show more information (if available) from error messages (https://github.com/ansible-collections/community.hrobot/pull/89)."

--- a/plugins/module_utils/robot.py
+++ b/plugins/module_utils/robot.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.six import PY3
 from ansible.module_utils.six.moves.urllib.error import HTTPError
 from ansible.module_utils.urls import fetch_url, open_url
@@ -33,6 +34,12 @@ def get_x_www_form_urlenconded_dict_from_list(key, values):
         return dict(('{key}[{index}]'.format(key=key, index=i), x) for i, x in enumerate(values))
 
 
+def _format_list(obj):
+    if not isinstance(obj, (list, tuple)):
+        return to_native(obj)
+    return [_format_list(e) for e in obj]
+
+
 def format_error_msg(error):
     # Reference: https://robot.hetzner.com/doc/webservice/en.html#errors
     msg = 'Request failed: {0} {1} ({2})'.format(
@@ -41,9 +48,9 @@ def format_error_msg(error):
         error['message'],
     )
     if error.get('missing'):
-        msg += '. Missing input parameters: {0}'.format(error['missing'])
+        msg += '. Missing input parameters: {0}'.format(_format_list(error['missing']))
     if error.get('invalid'):
-        msg += '. Invalid input parameters: {0}'.format(error['invalid'])
+        msg += '. Invalid input parameters: {0}'.format(_format_list(error['invalid']))
     if error.get('max_request') is not None:
         msg += '. Maximum allowed requests: {0}'.format(error['max_request'])
     if error.get('interval') is not None:

--- a/plugins/module_utils/robot.py
+++ b/plugins/module_utils/robot.py
@@ -33,6 +33,24 @@ def get_x_www_form_urlenconded_dict_from_list(key, values):
         return dict(('{key}[{index}]'.format(key=key, index=i), x) for i, x in enumerate(values))
 
 
+def format_error_msg(error):
+    # Reference: https://robot.hetzner.com/doc/webservice/en.html#errors
+    msg = 'Request failed: {0} {1} ({2})'.format(
+        error['status'],
+        error['code'],
+        error['message'],
+    )
+    if error.get('missing'):
+        msg += '. Missing input parameters: {0}'.format(error['missing'])
+    if error.get('invalid'):
+        msg += '. Invalid input parameters: {0}'.format(error['invalid'])
+    if error.get('max_request') is not None:
+        msg += '. Maximum allowed requests: {0}'.format(error['max_request'])
+    if error.get('interval') is not None:
+        msg += '. Time interval in seconds: {0}'.format(error['interval'])
+    return msg
+
+
 class PluginException(Exception):
     def __init__(self, message):
         super(PluginException, self).__init__(message)
@@ -85,11 +103,7 @@ def plugin_open_url_json(plugin, url, method='GET', timeout=10, data=None, heade
             if accept_errors:
                 if result['error']['code'] in accept_errors:
                     return result, result['error']['code']
-            raise PluginException('Request failed: {0} {1} ({2})'.format(
-                result['error']['status'],
-                result['error']['code'],
-                result['error']['message']
-            ))
+            raise PluginException(format_error_msg(result['error']))
         return result, None
     except ValueError:
         raise PluginException('Cannot decode content retrieved from {0}'.format(url))
@@ -125,11 +139,7 @@ def fetch_url_json(module, url, method='GET', timeout=10, data=None, headers=Non
             if accept_errors:
                 if result['error']['code'] in accept_errors:
                     return result, result['error']['code']
-            module.fail_json(msg='Request failed: {0} {1} ({2})'.format(
-                result['error']['status'],
-                result['error']['code'],
-                result['error']['message']
-            ))
+            module.fail_json(msg=format_error_msg(result['error']))
         return result, None
     except ValueError:
         module.fail_json(msg='Cannot decode content retrieved from {0}'.format(url))

--- a/plugins/module_utils/robot.py
+++ b/plugins/module_utils/robot.py
@@ -139,7 +139,7 @@ def fetch_url_json(module, url, method='GET', timeout=10, data=None, headers=Non
             if accept_errors:
                 if result['error']['code'] in accept_errors:
                     return result, result['error']['code']
-            module.fail_json(msg=format_error_msg(result['error']))
+            module.fail_json(msg=format_error_msg(result['error']), error=result['error'])
         return result, None
     except ValueError:
         module.fail_json(msg='Cannot decode content retrieved from {0}'.format(url))

--- a/plugins/modules/firewall.py
+++ b/plugins/modules/firewall.py
@@ -93,6 +93,8 @@ options:
           name:
             description:
               - Name of the firewall rule.
+              - Note that Hetzner restricts the characters that can be used for rule names. At the moment, only
+                letters C(a-z), C(A-Z), space, and the symbols C(.), C(-), C(+), C(_), and C(@) are allowed.
             type: str
           ip_version:
             description:
@@ -146,6 +148,8 @@ options:
           name:
             description:
               - Name of the firewall rule.
+              - Note that Hetzner restricts the characters that can be used for rule names. At the moment, only
+                letters C(a-z), C(A-Z), space, and the symbols C(.), C(-), C(+), C(_), and C(@) are allowed.
             type: str
           ip_version:
             description:

--- a/plugins/modules/firewall.py
+++ b/plugins/modules/firewall.py
@@ -248,7 +248,8 @@ EXAMPLES = r'''
           dst_port: '32768-65535'
           tcp_flags: ack
           action: accept
-        - name: Allow everything to ports 20-23 from 4.3.2.1/24 (IPv4 only)
+        - name: Allow restricted access from some known IPv4 addresses
+          # Allow everything to ports 20-23 from 4.3.2.1/24 (IPv4 only)
           ip_version: ipv4
           src_ip: 4.3.2.1/24
           dst_port: '20-23'

--- a/plugins/modules/firewall.py
+++ b/plugins/modules/firewall.py
@@ -236,7 +236,8 @@ EXAMPLES = r'''
     allowlist_hos: true
     rules:
       input:
-        - name: Allow ICMP protocol, so you can ping your server
+        - name: Allow ICMP protocol
+          # This is needed so you can ping your server
           ip_version: ipv4
           protocol: icmp
           action: accept

--- a/tests/unit/plugins/module_utils/test_failover.py
+++ b/tests/unit/plugins/module_utils/test_failover.py
@@ -67,14 +67,22 @@ GET_FAILOVER_FAIL = [
                 ),
             )).encode('utf-8'),
         )),
-        'Request failed: 400 foo (bar)'
+        'Request failed: 400 foo (bar)',
+        {
+            'error': {
+                'code': 'foo',
+                'status': 400,
+                'message': 'bar',
+            },
+        },
     ),
     (
         '1.2.3.4',
         (None, dict(
             body='{"foo": "bar"}'.encode('utf-8'),
         )),
-        'Cannot interpret result: {"foo": "bar"}'
+        'Cannot interpret result: {"foo": "bar"}',
+        {},
     ),
 ]
 
@@ -87,16 +95,16 @@ def test_get_failover_record(monkeypatch, ip, return_value, result, record):
     assert failover.get_failover_record(module, ip) == record
 
 
-@pytest.mark.parametrize("ip, return_value, result", GET_FAILOVER_FAIL)
-def test_get_failover_record_fail(monkeypatch, ip, return_value, result):
+@pytest.mark.parametrize("ip, return_value, fail_msg, fail_kwargs", GET_FAILOVER_FAIL)
+def test_get_failover_record_fail(monkeypatch, ip, return_value, fail_msg, fail_kwargs):
     module = get_module_mock()
     robot.fetch_url = MagicMock(return_value=copy.deepcopy(return_value))
 
     with pytest.raises(ModuleFailException) as exc:
         failover.get_failover_record(module, ip)
 
-    assert exc.value.fail_msg == result
-    assert exc.value.fail_kwargs == dict()
+    assert exc.value.fail_msg == fail_msg
+    assert exc.value.fail_kwargs == fail_kwargs
 
 
 @pytest.mark.parametrize("ip, return_value, result, record", GET_FAILOVER_SUCCESS)
@@ -107,16 +115,16 @@ def test_get_failover(monkeypatch, ip, return_value, result, record):
     assert failover.get_failover(module, ip) == result
 
 
-@pytest.mark.parametrize("ip, return_value, result", GET_FAILOVER_FAIL)
-def test_get_failover_fail(monkeypatch, ip, return_value, result):
+@pytest.mark.parametrize("ip, return_value, fail_msg, fail_kwargs", GET_FAILOVER_FAIL)
+def test_get_failover_fail(monkeypatch, ip, return_value, fail_msg, fail_kwargs):
     module = get_module_mock()
     robot.fetch_url = MagicMock(return_value=copy.deepcopy(return_value))
 
     with pytest.raises(ModuleFailException) as exc:
         failover.get_failover(module, ip)
 
-    assert exc.value.fail_msg == result
-    assert exc.value.fail_kwargs == dict()
+    assert exc.value.fail_msg == fail_msg
+    assert exc.value.fail_kwargs == fail_kwargs
 
 
 # ########################################################################################
@@ -164,7 +172,14 @@ SET_FAILOVER_FAIL = [
                 ),
             )).encode('utf-8'),
         )),
-        'Request failed: 400 foo (bar)'
+        'Request failed: 400 foo (bar)',
+        {
+            'error': {
+                'code': 'foo',
+                'status': 400,
+                'message': 'bar',
+            },
+        },
     ),
 ]
 
@@ -177,13 +192,13 @@ def test_set_failover(monkeypatch, ip, value, return_value, result):
     assert failover.set_failover(module, ip, value) == result
 
 
-@pytest.mark.parametrize("ip, value, return_value, result", SET_FAILOVER_FAIL)
-def test_set_failover_fail(monkeypatch, ip, value, return_value, result):
+@pytest.mark.parametrize("ip, value, return_value, fail_msg, fail_kwargs", SET_FAILOVER_FAIL)
+def test_set_failover_fail(monkeypatch, ip, value, return_value, fail_msg, fail_kwargs):
     module = get_module_mock()
     robot.fetch_url = MagicMock(return_value=copy.deepcopy(return_value))
 
     with pytest.raises(ModuleFailException) as exc:
         failover.set_failover(module, ip, value)
 
-    assert exc.value.fail_msg == result
-    assert exc.value.fail_kwargs == dict()
+    assert exc.value.fail_msg == fail_msg
+    assert exc.value.fail_kwargs == fail_kwargs

--- a/tests/unit/plugins/module_utils/test_robot.py
+++ b/tests/unit/plugins/module_utils/test_robot.py
@@ -89,11 +89,32 @@ FETCH_URL_JSON_FAIL = [
                     code="foo",
                     status=400,
                     message="bar",
+                    missing=None,
+                    invalid=None,
+                    max_request=None,
+                    interval=None,
                 ),
             )).encode('utf-8'),
         )),
         ['bar'],
         'Request failed: 400 foo (bar)'
+    ),
+    (
+        (None, dict(
+            body=json.dumps(dict(
+                error=dict(
+                    code="foo",
+                    status=400,
+                    message="bar",
+                    missing=["foo"],
+                    invalid=["bar"],
+                    max_request=0,
+                    interval=0,
+                ),
+            )).encode('utf-8'),
+        )),
+        None,
+        "Request failed: 400 foo (bar). Missing input parameters: ['foo']. Invalid input parameters: ['bar']. Maximum allowed requests: 0. Time interval in seconds: 0"
     ),
     (
         (None, dict(body='{this is not json}'.encode('utf-8'))),

--- a/tests/unit/plugins/module_utils/test_robot.py
+++ b/tests/unit/plugins/module_utils/test_robot.py
@@ -169,15 +169,15 @@ def test_fetch_url_json(monkeypatch, return_value, accept_errors, result):
     assert robot.fetch_url_json(module, 'https://foo/bar', accept_errors=accept_errors) == result
 
 
-@pytest.mark.parametrize("return_value, accept_errors, result, fail_kwargs", FETCH_URL_JSON_FAIL)
-def test_fetch_url_json_fail(monkeypatch, return_value, accept_errors, result, fail_kwargs):
+@pytest.mark.parametrize("return_value, accept_errors, fail_msg, fail_kwargs", FETCH_URL_JSON_FAIL)
+def test_fetch_url_json_fail(monkeypatch, return_value, accept_errors, fail_msg, fail_kwargs):
     module = get_module_mock()
     robot.fetch_url = MagicMock(return_value=return_value)
 
     with pytest.raises(ModuleFailException) as exc:
         robot.fetch_url_json(module, 'https://foo/bar', accept_errors=accept_errors)
 
-    assert exc.value.fail_msg == result
+    assert exc.value.fail_msg == fail_msg
     assert exc.value.fail_kwargs == fail_kwargs
 
 
@@ -206,8 +206,8 @@ def test_plugin_open_url_json(monkeypatch, return_value, accept_errors, result):
     assert robot.plugin_open_url_json(plugin, 'https://foo/bar', accept_errors=accept_errors) == result
 
 
-@pytest.mark.parametrize("return_value, accept_errors, result", FETCH_URL_JSON_FAIL)
-def test_plugin_open_url_json_fail(monkeypatch, return_value, accept_errors, result):
+@pytest.mark.parametrize("return_value, accept_errors, fail_msg, fail_kwargs", FETCH_URL_JSON_FAIL)
+def test_plugin_open_url_json_fail(monkeypatch, return_value, accept_errors, fail_msg, fail_kwargs):
     response = MagicMock()
     response.read = MagicMock(return_value=return_value[1].get('body', ''))
     robot.open_url = MagicMock(side_effect=robot.HTTPError('https://foo/bar', 400, 'Error!', {}, response))
@@ -216,7 +216,7 @@ def test_plugin_open_url_json_fail(monkeypatch, return_value, accept_errors, res
     with pytest.raises(robot.PluginException) as exc:
         robot.plugin_open_url_json(plugin, 'https://foo/bar', accept_errors=accept_errors)
 
-    assert exc.value.error_message == result
+    assert exc.value.error_message == fail_msg
 
 
 def test_plugin_open_url_json_fail_other(monkeypatch):

--- a/tests/unit/plugins/module_utils/test_robot.py
+++ b/tests/unit/plugins/module_utils/test_robot.py
@@ -177,6 +177,8 @@ def test_fetch_url_json_fail(monkeypatch, return_value, accept_errors, fail_msg,
     with pytest.raises(ModuleFailException) as exc:
         robot.fetch_url_json(module, 'https://foo/bar', accept_errors=accept_errors)
 
+    print(exc.value.fail_msg)
+    print(exc.value.fail_kwargs)
     assert exc.value.fail_msg == fail_msg
     assert exc.value.fail_kwargs == fail_kwargs
 
@@ -192,6 +194,8 @@ def test_fetch_url_json_empty(monkeypatch):
     with pytest.raises(ModuleFailException) as exc:
         robot.fetch_url_json(module, 'https://foo/bar', allow_empty_result=True)
 
+    print(exc.value.fail_msg)
+    print(exc.value.fail_kwargs)
     assert exc.value.fail_msg == 'Cannot retrieve content from https://foo/bar, HTTP status code 400'
     assert exc.value.fail_kwargs == dict()
 
@@ -216,6 +220,7 @@ def test_plugin_open_url_json_fail(monkeypatch, return_value, accept_errors, fai
     with pytest.raises(robot.PluginException) as exc:
         robot.plugin_open_url_json(plugin, 'https://foo/bar', accept_errors=accept_errors)
 
+    print(exc.value.error_message)
     assert exc.value.error_message == fail_msg
 
 


### PR DESCRIPTION
##### SUMMARY
Improve error reporting by giving more details from errors. Also return the raw error object in modules (useful in case Hetzner adds more details later).

Also improves documentation for the `firewall` module by mentioning Hetzner's restriction on firewall rule names, and fixing an example which was using an invalid rule name.

Fixes #88.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
robot module_utils
firewall module
