### PR TITLE
Inventory plugin: rename filters to simple_filters

### DIFF
--- a/changelogs/fragments/94-inventory-filters.yml
+++ b/changelogs/fragments/94-inventory-filters.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - robot inventory plugin - the ``filters`` option has been renamed to ``simple_filters``. The old name still works until community.hrobot 2.0.0.
+    Then it will change to allow more complex filtering with the ``community.library_inventory_filtering_v1`` collection's functionality
+    (https://github.com/ansible-collections/community.hrobot/pull/94).

--- a/changelogs/fragments/94-inventory-filters.yml
+++ b/changelogs/fragments/94-inventory-filters.yml
@@ -2,3 +2,6 @@ minor_changes:
   - robot inventory plugin - the ``filters`` option has been renamed to ``simple_filters``. The old name still works until community.hrobot 2.0.0.
     Then it will change to allow more complex filtering with the ``community.library_inventory_filtering_v1`` collection's functionality
     (https://github.com/ansible-collections/community.hrobot/pull/94).
+deprecated_features:
+  - robot inventory plugin - the ``filters`` option has been renamed to ``simple_filters``. The old name will stop working in community.hrobot 2.0.0
+    (https://github.com/ansible-collections/community.hrobot/pull/94).

--- a/plugins/inventory/robot.py
+++ b/plugins/inventory/robot.py
@@ -38,13 +38,17 @@ DOCUMENTATION = r"""
         hetzner_password:
             env:
                 - name: HROBOT_API_PASSWORD
-        filters:
+        simple_filters:
             description:
                 - A dictionary of filter value pairs.
                 - Available filters are listed here are keys of server like C(status) or C(server_ip).
                 - See U(https://robot.your-server.de/doc/webservice/en.html#get-server) for all values that can be used.
+                - This option has been renamed from O(filters) to O(simple_filters) in community.hrobot 1.9.0.
+                  The old name can still be used until community.hrobot 2.0.0.
             type: dict
             default: {}
+            aliases:
+                - filters
 """
 
 EXAMPLES = r"""
@@ -63,7 +67,7 @@ hetzner_password: '{{ (lookup("community.sops.sops", "keys/hetzner.sops.yaml") |
 
 # Example using constructed features to create groups
 plugin: community.hrobot.robot
-filters:
+simple_filters:
   status: ready
   traffic: unlimited
 # keyed_groups may be used to create custom groups
@@ -143,7 +147,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         self.populate(servers)
 
     def populate(self, servers):
-        filters = self.get_option('filters')
+        filters = self.get_option('simple_filters')
         strict = self.get_option('strict')
         server_lists = []
         for server in servers:

--- a/plugins/inventory/robot.py
+++ b/plugins/inventory/robot.py
@@ -113,9 +113,17 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def parse(self, inventory, loader, path, cache=True):
         super(InventoryModule, self).parse(inventory, loader, path)
         servers = {}
-        config = self._read_config_data(path)
+        orig_config = self._read_config_data(path)
         self.load_cache_plugin()
         cache_key = self.get_cache_key(path)
+
+        if 'filters' in orig_config:
+            display.deprecated(
+                'The `filters` option of the community.hrobot.robot inventory plugin has been renamed to `simple_filters`. '
+                'The old name will stop working in community.hrobot 2.0.0.',
+                collection_name='community.hrobot',
+                version='2.0.0',
+            )
 
         self.templar = Templar(loader=loader)
 

--- a/tests/unit/plugins/inventory/test_robot.py
+++ b/tests/unit/plugins/inventory/test_robot.py
@@ -60,7 +60,7 @@ def inventory():
 
 
 def get_option(option):
-    if option == 'filters':
+    if option == 'simple_filters':
         return {}
     if option == 'hetzner_user':
         return 'test'
@@ -159,7 +159,7 @@ def test_inventory_file_simple(mocker):
     plugin: community.hrobot.robot
     hetzner_user: test
     hetzner_password: hunter2
-    filters:
+    simple_filters:
       dc: foo
     """)}
     im = InventoryManager(loader=DictDataLoader(inventory_file), sources=inventory_filename)
@@ -216,7 +216,7 @@ def test_inventory_file_simple_2(mocker):
     plugin: community.hrobot.robot
     hetzner_user: '{{ "test" }}'
     hetzner_password: '{{ "hunter2" }}'
-    filters:
+    simple_filters:
       dc: foo
     """)}
     im = InventoryManager(loader=DictDataLoader(inventory_file), sources=inventory_filename)
@@ -260,7 +260,7 @@ def test_inventory_file_fail(mocker, error_result):
     plugin: community.hrobot.robot
     hetzner_user: test
     hetzner_password: hunter2
-    filters:
+    simple_filters:
       dc: foo
     """)}
     im = InventoryManager(loader=DictDataLoader(inventory_file), sources=inventory_filename)


### PR DESCRIPTION
##### SUMMARY
This allows to re-use `filters` for the functionality provided by [community.library_inventory_filtering_v1](https://github.com/ansible-collections/community.library_inventory_filtering/) in the next major release.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
inventory plugin
