### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you use the Ansible package and do not update collections independently, use 
 - `community.hrobot.failover_ip_info` module
 - `community.hrobot.firewall` module
 - `community.hrobot.firewall_info` module
-- `community.hrobot.hrobot` inventory plugin
+- `community.hrobot.robot` inventory plugin
 
 You can find [documentation for the modules and plugins in this collection here](https://docs.ansible.com/ansible/devel/collections/community/hrobot/).
 


### PR DESCRIPTION
mentioned inventory plugin should be `community.hrobot.robot` as the filename suggests

##### SUMMARY
Readme suggest `community.hrobot.hrobot`, but it needs to be `community.hrobot.robot` according to filename in [inventory](https://github.com/ansible-collections/community.hrobot/tree/main/plugins/inventory)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
README.md

##### ADDITIONAL INFORMATION
none 
