### PR TITLE
Add stable-2.17 to CI; copy 2.17 ignore.txt files to 2.18

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -34,6 +34,7 @@ jobs:
           - stable-2.14
           - stable-2.15
           - stable-2.16
+          - stable-2.17
           - devel
     # Ansible-test on various stable branches does not yet work well with cgroups v2.
     # Since ubuntu-latest now uses Ubuntu 22.04, we need to fall back to the ubuntu-20.04
@@ -75,6 +76,7 @@ jobs:
           - stable-2.14
           - stable-2.15
           - stable-2.16
+          - stable-2.17
           - devel
 
     steps:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Please note that this collection does **not** support Windows targets.
 
 ## Tested with Ansible
 
-Tested with the current Ansible 2.9, ansible-base 2.10, ansible-core 2.11, ansible-core 2.12, ansible-core 2.13, ansible-core 2.14, ansible-core 2.15, and ansible-core 2.16 releases and the current development version of ansible-core. Ansible versions before 2.9.10 are not supported.
+Tested with the current Ansible 2.9, ansible-base 2.10, ansible-core 2.11, ansible-core 2.12, ansible-core 2.13, ansible-core 2.14, ansible-core 2.15, ansible-core 2.16, and ansible-core 2.17 releases and the current development version of ansible-core. Ansible versions before 2.9.10 are not supported.
 
 ## External requirements
 

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -1,0 +1,1 @@
+tests/ee/roles/smoke/library/smoke_ipaddress.py shebang

--- a/tests/sanity/ignore-2.18.txt.license
+++ b/tests/sanity/ignore-2.18.txt.license
@@ -1,0 +1,3 @@
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: Ansible Project


### PR DESCRIPTION
##### SUMMARY
Ref: https://forum.ansible.com/t/ansible-core-devel-bumped-to-2-18-0-dev0-stable-2-17-branch-created/4695

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
