### PR TITLE
[2.0.0] Prepare new major release: remove deprecations, add community.library_inventory_filtering_v1 dependency, add new filter option

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -51,6 +51,8 @@ jobs:
         with:
           ansible-core-version: ${{ matrix.ansible }}
           testing-type: sanity
+          pre-test-cmd: >-
+            git clone --depth=1 --single-branch --branch stable-1 https://github.com/ansible-collections/community.library_inventory_filtering.git ../../community/library_inventory_filtering_v1
 
   units:
     # Ansible-test on various stable branches does not yet work well with cgroups v2.
@@ -89,4 +91,6 @@ jobs:
           testing-type: units
           # NOTE: we're installing with git to work around Galaxy being a huge PITA (https://github.com/ansible/galaxy/issues/2429)
           pre-test-cmd: >-
+            git clone --depth=1 --single-branch --branch stable-1 https://github.com/ansible-collections/community.library_inventory_filtering.git ../../community/library_inventory_filtering_v1
+            ;
             git clone --depth=1 --single-branch https://github.com/ansible-collections/community.internal_test_tools.git ../../community/internal_test_tools

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -26,25 +26,12 @@ jobs:
         ansible:
           # It's important that Sanity is tested against all stable-X.Y branches
           # Testing against `devel` may fail as new tests are added.
-          - stable-2.9
-          - stable-2.10
-          - stable-2.11
-          - stable-2.12
-          - stable-2.13
           - stable-2.14
           - stable-2.15
           - stable-2.16
           - stable-2.17
           - devel
-    # Ansible-test on various stable branches does not yet work well with cgroups v2.
-    # Since ubuntu-latest now uses Ubuntu 22.04, we need to fall back to the ubuntu-20.04
-    # image for these stable branches. The list of branches where this is necessary will
-    # shrink over time, check out https://github.com/ansible-collections/news-for-maintainers/issues/28
-    # for the latest list.
-    runs-on: >-
-      ${{ contains(fromJson(
-          '["stable-2.9", "stable-2.10", "stable-2.11"]'
-      ), matrix.ansible) && 'ubuntu-20.04' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     steps:
       - name: Perform sanity testing
         uses: felixfontein/ansible-test-gh-action@main
@@ -55,26 +42,13 @@ jobs:
             git clone --depth=1 --single-branch --branch stable-1 https://github.com/ansible-collections/community.library_inventory_filtering.git ../../community/library_inventory_filtering_v1
 
   units:
-    # Ansible-test on various stable branches does not yet work well with cgroups v2.
-    # Since ubuntu-latest now uses Ubuntu 22.04, we need to fall back to the ubuntu-20.04
-    # image for these stable branches. The list of branches where this is necessary will
-    # shrink over time, check out https://github.com/ansible-collections/news-for-maintainers/issues/28
-    # for the latest list.
-    runs-on: >-
-      ${{ contains(fromJson(
-          '["stable-2.9", "stable-2.10", "stable-2.11"]'
-      ), matrix.ansible) && 'ubuntu-20.04' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     name: Units (Ⓐ${{ matrix.ansible }})
     strategy:
       # As soon as the first unit test fails, cancel the others to free up the CI queue
       fail-fast: true
       matrix:
         ansible:
-          - stable-2.9
-          - stable-2.10
-          - stable-2.11
-          - stable-2.12
-          - stable-2.13
           - stable-2.14
           - stable-2.15
           - stable-2.16

--- a/.github/workflows/ee.yml
+++ b/.github/workflows/ee.yml
@@ -62,22 +62,6 @@ jobs:
             ansible_runner: ansible-runner
             base_image: quay.io/centos/centos:stream9
             pre_base: '"#"'
-          - name: ansible-core 2.13 @ RHEL UBI 8
-            ansible_core: https://github.com/ansible/ansible/archive/stable-2.13.tar.gz
-            ansible_runner: ansible-runner
-            other_deps: |2
-                python_interpreter:
-                  package_system: python39 python39-pip python39-wheel python39-cryptography
-            base_image: docker.io/redhat/ubi8:latest
-            pre_base: '"#"'
-          - name: ansible-core 2.12 @ CentOS Stream 8
-            ansible_core: https://github.com/ansible/ansible/archive/stable-2.12.tar.gz
-            ansible_runner: ansible-runner
-            other_deps: |2
-                python_interpreter:
-                  package_system: python39 python39-pip python39-wheel python39-cryptography
-            base_image: quay.io/centos/centos:stream8
-            pre_base: '"#"'
     runs-on: ubuntu-latest
     steps:
       - name: Check out code

--- a/.github/workflows/extra-tests.yml
+++ b/.github/workflows/extra-tests.yml
@@ -39,9 +39,11 @@ jobs:
         run: pip install https://github.com/ansible/ansible/archive/devel.tar.gz --disable-pip-version-check
 
       - name: Install collection dependencies
-        run: git clone --depth=1 --single-branch https://github.com/ansible-collections/community.internal_test_tools.git ./ansible_collections/community/internal_test_tools
+        run: |
+          git clone --depth=1 --single-branch --branch stable-1 https://github.com/ansible-collections/community.library_inventory_filtering.git ./ansible_collections/community/library_inventory_filtering_v1
+          git clone --depth=1 --single-branch https://github.com/ansible-collections/community.internal_test_tools.git ./ansible_collections/community/internal_test_tools
         # NOTE: we're installing with git to work around Galaxy being a huge PITA (https://github.com/ansible/galaxy/issues/2429)
-        # run: ansible-galaxy collection install community.internal_test_tools -p .
+        # run: ansible-galaxy collection install community.internal_test_tools community.library_inventory_filtering_v1 -p .
 
       - name: Run sanity tests
         run: ../../community/internal_test_tools/tools/run.py --color

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Please note that this collection does **not** support Windows targets.
 
 ## Tested with Ansible
 
-Tested with the current Ansible 2.9, ansible-base 2.10, ansible-core 2.11, ansible-core 2.12, ansible-core 2.13, ansible-core 2.14, ansible-core 2.15, ansible-core 2.16, and ansible-core 2.17 releases and the current development version of ansible-core. Ansible versions before 2.9.10 are not supported.
+Tested with the current ansible-core 2.14, ansible-core 2.15, ansible-core 2.16, and ansible-core 2.17 releases and the current development version of ansible-core. Ansible versions before 2.9.10 are not supported.
 
 ## External requirements
 

--- a/changelogs/fragments/2.0.0.yml
+++ b/changelogs/fragments/2.0.0.yml
@@ -11,3 +11,6 @@ major_changes:
     repository, you need to make sure that you also have to install the dependency
     if you are using the inventory plugin
     (https://github.com/ansible-collections/community.hrobot/pull/101).
+breaking_canges:
+  - "robot inventory plugin - ``filters`` is now no longer an alias of ``simple_filters``, but a new, different option
+     (https://github.com/ansible-collections/community.hrobot/pull/101).

--- a/changelogs/fragments/2.0.0.yml
+++ b/changelogs/fragments/2.0.0.yml
@@ -14,3 +14,6 @@ major_changes:
 breaking_canges:
   - "robot inventory plugin - ``filters`` is now no longer an alias of ``simple_filters``, but a new, different option
      (https://github.com/ansible-collections/community.hrobot/pull/101).
+minor_changes:
+  - "robot inventory plugin - add ``filter`` option which allows to include and exclude
+     hosts based on Jinja2 conditions (https://github.com/ansible-collections/community.hrobot/pull/101)."

--- a/changelogs/fragments/2.0.0.yml
+++ b/changelogs/fragments/2.0.0.yml
@@ -11,9 +11,9 @@ major_changes:
     repository, you need to make sure that you also have to install the dependency
     if you are using the inventory plugin
     (https://github.com/ansible-collections/community.hrobot/pull/101).
-breaking_canges:
+breaking_changes:
   - "robot inventory plugin - ``filters`` is now no longer an alias of ``simple_filters``, but a new, different option
-     (https://github.com/ansible-collections/community.hrobot/pull/101).
+     (https://github.com/ansible-collections/community.hrobot/pull/101)."
 minor_changes:
   - "robot inventory plugin - add ``filter`` option which allows to include and exclude
      hosts based on Jinja2 conditions (https://github.com/ansible-collections/community.hrobot/pull/101)."

--- a/changelogs/fragments/2.0.0.yml
+++ b/changelogs/fragments/2.0.0.yml
@@ -1,0 +1,13 @@
+release_summary: |
+  ...
+major_changes:
+  - The ``community.hrobot`` collection now depends on the ``community.library_inventory_filtering_v1``
+    collection. This utility collection provides host filtering functionality
+    for inventory plugins. If you use the Ansible community package, both collections
+    are included and you do not have to do anything special. If you install the
+    collection with ``ansible-galaxy collection install``, it will be installed
+    automatically. If you install the collection by copying the files of the collection
+    to a place where ansible-core can find it, for example by cloning the git
+    repository, you need to make sure that you also have to install the dependency
+    if you are using the inventory plugin
+    (https://github.com/ansible-collections/community.hrobot/pull/101).

--- a/changelogs/fragments/2.0.0.yml
+++ b/changelogs/fragments/2.0.0.yml
@@ -14,6 +14,14 @@ major_changes:
 breaking_changes:
   - "robot inventory plugin - ``filters`` is now no longer an alias of ``simple_filters``, but a new, different option
      (https://github.com/ansible-collections/community.hrobot/pull/101)."
+removed_features:
+  - "The collection no longer supports Ansible, ansible-base, and ansible-core releases
+     that are currently End of Life at the time of the 2.0.0 release. This means that
+     Ansible 2.9, ansible-base 2.10, ansible-core 2.11, ansible-core 2.12, ansible-core 2.13,
+     and ansible-core 2.14 are no longer supported. The collection might still work with these
+     versions, but it can stop working at any moment without advance notice, and this will not
+     be considered a bug
+     (https://github.com/ansible-collections/community.hrobot/pull/101)."
 minor_changes:
   - "robot inventory plugin - add ``filter`` option which allows to include and exclude
      hosts based on Jinja2 conditions (https://github.com/ansible-collections/community.hrobot/pull/101)."

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -29,3 +29,5 @@ issues: https://github.com/ansible-collections/community.hrobot/issues
 build_ignore:
   - .gitignore
   - changelogs/.plugin-cache.yaml
+dependencies:
+  community.library_inventory_filtering_v1: '>=1.0.0'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -7,7 +7,7 @@
 
 namespace: community
 name: hrobot
-version: 1.9.2
+version: 2.0.0
 readme: README.md
 authors:
   - Felix Fontein (github.com/felixfontein)

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -3,7 +3,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-requires_ansible: '>=2.9.10'
+requires_ansible: '>=2.14.0'
 action_groups:
   robot:
     - boot

--- a/plugins/inventory/robot.py
+++ b/plugins/inventory/robot.py
@@ -25,6 +25,7 @@ DOCUMENTATION = r"""
         - ansible.builtin.constructed
         - ansible.builtin.inventory_cache
         - community.hrobot.robot
+        - community.library_inventory_filtering_v1.inventory_filter
     notes:
         - The O(hetzner_user) and O(hetzner_password) options can be templated.
     options:
@@ -48,6 +49,8 @@ DOCUMENTATION = r"""
                   as an alias until community.hrobot 2.0.0. O(filters) is now used for something else.
             type: dict
             default: {}
+        filters:
+            version_added: 2.0.0
 """
 
 EXAMPLES = r"""
@@ -57,12 +60,18 @@ plugin: community.hrobot.robot
 filters:
   status: ready
 
-# Example showing encrypted credentials
+# Example showing encrypted credentials and using filters
 # (This assumes that Mozilla sops was used to encrypt keys/hetzner.sops.yaml, which contains two values
 # hetzner_username and hetzner_password. Needs the community.sops collection to decode that file.)
 plugin: community.hrobot.robot
 hetzner_user: '{{ (lookup("community.sops.sops", "keys/hetzner.sops.yaml") | from_yaml).hetzner_username }}'
 hetzner_password: '{{ (lookup("community.sops.sops", "keys/hetzner.sops.yaml") | from_yaml).hetzner_password }}'
+filters:
+  # Accept all servers in FSN1-DC1 and FSN1-DC2
+  - include: >-
+      hrobot_dc in ["FSN1-DC1", "FSN1-DC2"]
+  # Exclude all servers that didn't match any of the above filters
+  - exclude: true
 
 # Example using constructed features to create groups
 plugin: community.hrobot.robot
@@ -84,6 +93,8 @@ from ansible.errors import AnsibleError
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
 from ansible.template import Templar
 from ansible.utils.display import Display
+
+from ansible_collections.community.library_inventory_filtering_v1.plugins.plugin_utils.inventory_filter import parse_filters, filter_host
 
 from ansible_collections.community.hrobot.plugins.module_utils.robot import (
     BASE_URL,
@@ -147,14 +158,24 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         self.populate(servers)
 
     def populate(self, servers):
-        filters = self.get_option('simple_filters')
+        simple_filters = self.get_option('simple_filters')
+        filters = parse_filters(self.get_option('filters'))
         strict = self.get_option('strict')
         server_lists = []
         for server in servers:
             s = server['server']
             server_name = s.get('server_name') or s.get('server_ip') or str(s['server_number'])
-            matched = self.filter(s, filters)
+            matched = self.filter(s, simple_filters)
             if not matched:
+                continue
+
+            facts = {}
+            if 'server_ip' in s:
+                facts['ansible_host'] = make_unsafe(s['server_ip'])
+            for hostvar, hostval in s.items():
+                facts["{0}_{1}".format('hrobot', hostvar)] = make_unsafe(hostval)
+
+            if not filter_host(self, server_name, facts, filters):
                 continue
 
             if server_name in server_lists:
@@ -165,10 +186,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
             self.inventory.add_host(server_name)
             server_lists.append(server_name)
-            if 'server_ip' in s:
-                self.inventory.set_variable(server_name, 'ansible_host', make_unsafe(s['server_ip']))
-            for hostvar, hostval in s.items():
-                self.inventory.set_variable(server_name, "{0}_{1}".format('hrobot', hostvar), make_unsafe(hostval))
+            for key, value in facts.items():
+                self.inventory.set_variable(server_name, key, value)
 
             # Composed variables
             server_vars = self.inventory.get_host(server_name).get_vars()
@@ -180,9 +199,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             # Create groups based on variable values and add the corresponding hosts to it
             self._add_host_to_keyed_groups(self.get_option('keyed_groups'), server, server_name, strict=strict)
 
-    def filter(self, server, filters):
+    def filter(self, server, simple_filters):
         matched = True
-        for key, value in filters.items():
+        for key, value in simple_filters.items():
             if server.get(key) != value:
                 matched = False
                 break

--- a/plugins/inventory/robot.py
+++ b/plugins/inventory/robot.py
@@ -43,12 +43,11 @@ DOCUMENTATION = r"""
                 - A dictionary of filter value pairs.
                 - Available filters are listed here are keys of server like C(status) or C(server_ip).
                 - See U(https://robot.your-server.de/doc/webservice/en.html#get-server) for all values that can be used.
-                - This option has been renamed from O(filters) to O(simple_filters) in community.hrobot 1.9.0.
-                  The old name can still be used until community.hrobot 2.0.0.
+                - This option used to be called O(filters) before community.hrobot 2.0.0. It has been renamed from
+                  O(filters) to O(simple_filters) in community.hrobotdns 1.9.0, and the old name was still available
+                  as an alias until community.hrobot 2.0.0. O(filters) is now used for something else.
             type: dict
             default: {}
-            aliases:
-                - filters
 """
 
 EXAMPLES = r"""
@@ -114,17 +113,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def parse(self, inventory, loader, path, cache=True):
         super(InventoryModule, self).parse(inventory, loader, path)
         servers = {}
-        orig_config = self._read_config_data(path)
+        self._read_config_data(path)
         self.load_cache_plugin()
         cache_key = self.get_cache_key(path)
-
-        if 'filters' in orig_config:
-            display.deprecated(
-                'The `filters` option of the community.hrobot.robot inventory plugin has been renamed to `simple_filters`. '
-                'The old name will stop working in community.hrobot 2.0.0.',
-                collection_name='community.hrobot',
-                version='2.0.0',
-            )
 
         self.templar = Templar(loader=loader)
 

--- a/tests/unit/plugins/inventory/test_robot.py
+++ b/tests/unit/plugins/inventory/test_robot.py
@@ -63,6 +63,8 @@ def inventory():
 def get_option(option):
     if option == 'simple_filters':
         return {}
+    if option == 'filters':
+        return []
     if option == 'hetzner_user':
         return 'test'
     if option == 'hetzner_password':


### PR DESCRIPTION
##### SUMMARY
- Bump version to 3.0.0.
- Remove deprecated features, implement breaking changes.
- Remove `filters` alias of `simple_filters` option for inventory plugin.
- Add new `community.library_inventory_filtering_v1` collection dependency and use it to implement `filters` option for inventory plugin.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
various
