### PR TITLE
Use PHP array form encoding when sending multiple `authorized_key`

### DIFF
--- a/changelogs/fragments/fix-authorized_key-php-array-form-encoding.yml
+++ b/changelogs/fragments/fix-authorized_key-php-array-form-encoding.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - boot - Use PHP array form encoding when sending multiple `authorized_key` (https://github.com/ansible-collections/community.hrobot/pull/113).
+  - boot - use PHP array form encoding when sending multiple ``authorized_key`` (https://github.com/ansible-collections/community.hrobot/issues/112, https://github.com/ansible-collections/community.hrobot/pull/113).

--- a/changelogs/fragments/fix-authorized_key-php-array-form-encoding.yml
+++ b/changelogs/fragments/fix-authorized_key-php-array-form-encoding.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - robot - Use PHP array form encoding when sending multiple `authorized_key` (https://github.com/ansible-collections/community.hrobot/pull/113).

--- a/changelogs/fragments/fix-authorized_key-php-array-form-encoding.yml
+++ b/changelogs/fragments/fix-authorized_key-php-array-form-encoding.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - robot - Use PHP array form encoding when sending multiple `authorized_key` (https://github.com/ansible-collections/community.hrobot/pull/113).
+  - boot - Use PHP array form encoding when sending multiple `authorized_key` (https://github.com/ansible-collections/community.hrobot/pull/113).

--- a/plugins/modules/boot.py
+++ b/plugins/modules/boot.py
@@ -284,13 +284,13 @@ BOOT_CONFIGURATION_DATA = [
     ('rescue', 'rescue', {
         'os': ('os', 'os'),
         'arch': ('arch', 'arch'),
-        'authorized_keys': ('authorized_key', 'authorized_key'),
+        'authorized_keys': ('authorized_key', 'authorized_key[]'),
     }),
     ('install_linux', 'linux', {
         'dist': ('dist', 'dist'),
         'arch': ('arch', 'arch'),
         'lang': ('lang', 'lang'),
-        'authorized_keys': ('authorized_key', 'authorized_key'),
+        'authorized_keys': ('authorized_key', 'authorized_key[]'),
     }),
     ('install_vnc', 'vnc', {
         'dist': ('dist', 'dist'),

--- a/plugins/modules/boot.py
+++ b/plugins/modules/boot.py
@@ -404,7 +404,7 @@ def main():
                     if should is None:
                         continue
                     # unfold the return object for the idempotence check to work correctly
-                    has = existing.get(data_key)
+                    has = existing.get(result_key)
                     if has and option_key == 'authorized_keys':
                         has = [x['key']['fingerprint'] for x in has]
                     if isinstance(has, list):

--- a/tests/unit/plugins/modules/test_boot.py
+++ b/tests/unit/plugins/modules/test_boot.py
@@ -473,9 +473,9 @@ class TestHetznerBoot(BaseTestModule):
             .expect_form_value('dist', 'Debian 11 base')
             .expect_form_value('arch', '32')
             .expect_form_value('lang', 'fr')
-            .expect_form_present('authorized_key')
-            # .expect_form_value('authorized_key', 'e4:47:42:71:81:62:bf:06:1c:23:fa:f3:8f:7b:6f:d0')
-            # .expect_form_value('authorized_key', 'aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99')
+            .expect_form_present('authorized_key[]')
+            # .expect_form_value('authorized_key[]', 'e4:47:42:71:81:62:bf:06:1c:23:fa:f3:8f:7b:6f:d0')
+            # .expect_form_value('authorized_key[]', 'aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99')
             .result_json({
                 'linux': create_linux_active(dist='Debian 11 base', lang='fr', arch=32, authorized_key=[
                     {


### PR DESCRIPTION
##### SUMMARY

PHP required arrays to contains `[]` in the parameters key. Without the brackets, only a single value will be parsed. See as example:

```
$ php -r "echo http_build_query(array('authorized_key' => array('key1', 'key2', 'key3')));"
authorized_key%5B0%5D=key1&authorized_key%5B1%5D=key2&authorized_key%5B2%5D=key3%
```

More about this array syntax: https://www.php.net/manual/en/function.parse-str.php#76792

Closes #112

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME

`community.hrobot.boot`

