### PR TITLE
Add 'idempotent' attribute

### DIFF
--- a/plugins/doc_fragments/attributes.py
+++ b/plugins/doc_fragments/attributes.py
@@ -20,7 +20,7 @@ attributes:
     description: Will return details on what has changed (or possibly needs changing in C(check_mode)), when in diff mode.
   idempotent:
     description:
-      - When run twice in a row with the same arguments, the second invocation indicates no change.
+      - When run twice in a row outside check mode, with the same arguments, the second invocation indicates no change.
       - This assumes that the system controlled/queried by the module has not changed in a relevant way.
 """
 

--- a/plugins/doc_fragments/attributes.py
+++ b/plugins/doc_fragments/attributes.py
@@ -18,6 +18,20 @@ attributes:
     description: Can run in C(check_mode) and return changed status prediction without modifying target.
   diff_mode:
     description: Will return details on what has changed (or possibly needs changing in C(check_mode)), when in diff mode.
+  idempotent:
+    description:
+      - When run twice in a row with the same arguments, the second invocation indicates no change.
+      - This assumes that the system controlled/queried by the module has not changed in a relevant way.
+"""
+
+    # Should be used together with the standard fragment
+    IDEMPOTENT_NOT_MODIFY_STATE = r"""
+options: {}
+attributes:
+  idempotent:
+    support: full
+    details:
+      - This action does not modify state.
 """
 
     # Should be used together with the standard fragment

--- a/plugins/modules/boot.py
+++ b/plugins/modules/boot.py
@@ -34,6 +34,8 @@ attributes:
     support: full
   diff_mode:
     support: none
+  idempotent:
+    support: full
 
 options:
   server_number:

--- a/plugins/modules/failover_ip.py
+++ b/plugins/modules/failover_ip.py
@@ -34,6 +34,8 @@ attributes:
     support: full
   diff_mode:
     support: full
+  idempotent:
+    support: full
 
 options:
   failover_ip:

--- a/plugins/modules/failover_ip_info.py
+++ b/plugins/modules/failover_ip_info.py
@@ -26,6 +26,7 @@ extends_documentation_fragment:
   - community.hrobot.robot
   - community.hrobot.attributes
   - community.hrobot.attributes.actiongroup_robot
+  - community.hrobot.attributes.idempotent_not_modify_state
   - community.hrobot.attributes.info_module
 
 attributes:

--- a/plugins/modules/firewall.py
+++ b/plugins/modules/firewall.py
@@ -38,6 +38,8 @@ attributes:
     support: full
   diff_mode:
     support: full
+  idempotent:
+    support: full
 
 options:
   server_ip:

--- a/plugins/modules/firewall_info.py
+++ b/plugins/modules/firewall_info.py
@@ -26,6 +26,7 @@ extends_documentation_fragment:
   - community.hrobot.robot
   - community.hrobot.attributes
   - community.hrobot.attributes.actiongroup_robot
+  - community.hrobot.attributes.idempotent_not_modify_state
   - community.hrobot.attributes.info_module
 
 attributes:

--- a/plugins/modules/reset.py
+++ b/plugins/modules/reset.py
@@ -29,6 +29,10 @@ attributes:
     support: full
   diff_mode:
     support: none
+  idempotent:
+    support: none
+    details:
+      - This module performs an action on every invocation.
 
 options:
   server_number:

--- a/plugins/modules/reverse_dns.py
+++ b/plugins/modules/reverse_dns.py
@@ -32,6 +32,8 @@ attributes:
     support: full
   diff_mode:
     support: none
+  idempotent:
+    support: full
 
 options:
   ip:

--- a/plugins/modules/server.py
+++ b/plugins/modules/server.py
@@ -30,6 +30,8 @@ attributes:
     support: full
   diff_mode:
     support: none
+  idempotent:
+    support: full
 
 options:
   server_number:

--- a/plugins/modules/server_info.py
+++ b/plugins/modules/server_info.py
@@ -21,6 +21,7 @@ extends_documentation_fragment:
   - community.hrobot.robot
   - community.hrobot.attributes
   - community.hrobot.attributes.actiongroup_robot
+  - community.hrobot.attributes.idempotent_not_modify_state
   - community.hrobot.attributes.info_module
 
 attributes:

--- a/plugins/modules/ssh_key.py
+++ b/plugins/modules/ssh_key.py
@@ -32,6 +32,8 @@ attributes:
     support: full
   diff_mode:
     support: none
+  idempotent:
+    support: full
 
 options:
   state:

--- a/plugins/modules/ssh_key_info.py
+++ b/plugins/modules/ssh_key_info.py
@@ -24,6 +24,7 @@ extends_documentation_fragment:
   - community.hrobot.robot
   - community.hrobot.attributes
   - community.hrobot.attributes.actiongroup_robot
+  - community.hrobot.attributes.idempotent_not_modify_state
   - community.hrobot.attributes.info_module
 attributes:
   action_group:

--- a/plugins/modules/v_switch.py
+++ b/plugins/modules/v_switch.py
@@ -32,6 +32,8 @@ attributes:
     support: full
   diff_mode:
     support: none
+  idempotent:
+    support: full
 
 options:
   vlan:


### PR DESCRIPTION
##### SUMMARY
Adds a new attribute `idempotent` for module documentation, which states whether (resp. under which circumstances) the module is idempotent.

Related PRs:
- https://github.com/ansible-collections/community.dns/pull/238
- https://github.com/ansible-collections/community.crypto/pull/833
- https://github.com/ansible-collections/community.docker/pull/1022
- https://github.com/ansible-collections/community.routeros/pull/337
- https://github.com/ansible-collections/community.sops/pull/217

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
module documentation
