### PR TITLE
Add `storagebox_subaccount_info` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ If you use the Ansible package and do not update collections independently, use 
 - `community.hrobot.storagebox_snapshot_info` module
 - `community.hrobot.storagebox_snapshot_plan` module
 - `community.hrobot.storagebox_snapshot_plan_info` module
+- `community.hrobot.storagebox_subaccount_info` module
 - `community.hrobot.v_switch` module
 - `community.hrobot.robot` inventory plugin
 

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -25,4 +25,5 @@ action_groups:
     - storagebox_snapshot_info
     - storagebox_snapshot_plan
     - storagebox_snapshot_plan_info
+    - storagebox_subaccount_info
     - v_switch

--- a/plugins/modules/storagebox_subaccount_info.py
+++ b/plugins/modules/storagebox_subaccount_info.py
@@ -46,6 +46,7 @@ EXAMPLES = r"""
   ansible.builtin.debug:
     msg: "Username of the first subaccount: {{ result.subaccounts[0].username }}"
 """
+
 RETURN = r"""
 subaccounts:
   description:

--- a/plugins/modules/storagebox_subaccount_info.py
+++ b/plugins/modules/storagebox_subaccount_info.py
@@ -1,0 +1,161 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2025 Victor LEFEBVRE <dev@vic1707.xyz>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+DOCUMENTATION = r"""
+module: storagebox_subaccount_info
+short_description: Query the subaccounts for a storage box
+version_added: 2.4.0
+author:
+  - Victor LEFEBVRE (@vic1707)
+description:
+  - Query the subaccounts for a storage box.
+extends_documentation_fragment:
+  - community.hrobot.robot
+  - community.hrobot.attributes
+  - community.hrobot.attributes.actiongroup_robot
+  - community.hrobot.attributes.idempotent_not_modify_state
+  - community.hrobot.attributes.info_module
+
+options:
+  storagebox_id:
+    description:
+      - The ID of the storage box to query.
+    type: int
+    required: true
+"""
+
+EXAMPLES = r"""
+---
+- name: Query the subaccounts
+  community.hrobot.storagebox_subaccount_info:
+    hetzner_user: foo
+    hetzner_password: bar
+    id: 123
+  register: result
+
+- name: Output data
+  ansible.builtin.debug:
+    msg: "Username of the first subaccount: {{ result.subaccount[0].username }}"
+"""
+RETURN = r"""
+subaccount:
+  description:
+    - The storage box's info.
+    - All date and time parameters are in UTC.
+  returned: success
+  type: list
+  elements: dict
+  contains:
+    username:
+      description:
+        - Username of the sub-account.
+      type: str
+      sample: "u2342-sub1"
+      returned: success
+    accountid:
+      description:
+        - Username of the main user.
+      type: str
+      sample: "u2342"
+      returned: success
+    server:
+      description:
+        - Server on which the sub-account resides.
+      type: str
+      sample: "sb1234.your-storagebox.de"
+      returned: success
+    homedirectory:
+      description:
+        - Homedirectory of the sub-account.
+      type: str
+      sample: "/home/u2342-sub1"
+      returned: success
+    samba:
+      description:
+        - Status of Samba support.
+      type: bool
+      sample: true
+      returned: success
+    ssh:
+      description:
+        - Status of SSH support.
+      type: bool
+      sample: true
+      returned: success
+    external_reachability:
+      description:
+        - Status of external reachability.
+      type: bool
+      sample: false
+      returned: success
+    webdav:
+      description:
+        - Status of WebDAV support.
+      type: bool
+      sample: true
+      returned: success
+    readonly:
+      description:
+        - Indicates if the sub-account is in readonly mode.
+      type: bool
+      sample: false
+      returned: success
+    createtime:
+      description:
+        - Timestamp when the sub-account was created.
+      type: str
+      sample: "2023-08-25T14:23:05Z"
+      returned: success
+    comment:
+      description:
+        - Custom comment for the sub-account.
+      type: str
+      sample: "This is a subaccount"
+      returned: success
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.community.hrobot.plugins.module_utils.robot import (
+    BASE_URL,
+    ROBOT_DEFAULT_ARGUMENT_SPEC,
+    fetch_url_json,
+)
+
+
+def main():
+    argument_spec = dict(
+        storagebox_id=dict(type="int", required=True),
+    )
+    argument_spec.update(ROBOT_DEFAULT_ARGUMENT_SPEC)
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    storagebox_id = module.params["storagebox_id"]
+
+    url = "{0}/storagebox/{1}/subaccount".format(BASE_URL, storagebox_id)
+    result, error = fetch_url_json(module, url, accept_errors=["STORAGEBOX_NOT_FOUND"])
+    if error:
+        module.fail_json(
+            msg="Storagebox with ID {0} does not exist".format(storagebox_id)
+        )
+
+    module.exit_json(
+        changed=False,
+        subaccounts=[item["subaccount"] for item in result],
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()  # pragma: no cover

--- a/plugins/modules/storagebox_subaccount_info.py
+++ b/plugins/modules/storagebox_subaccount_info.py
@@ -39,15 +39,15 @@ EXAMPLES = r"""
   community.hrobot.storagebox_subaccount_info:
     hetzner_user: foo
     hetzner_password: bar
-    id: 123
+    storage_box_id: 123
   register: result
 
 - name: Output data
   ansible.builtin.debug:
-    msg: "Username of the first subaccount: {{ result.subaccount[0].username }}"
+    msg: "Username of the first subaccount: {{ result.subaccounts[0].username }}"
 """
 RETURN = r"""
-subaccount:
+subaccounts:
   description:
     - The storage box's info.
     - All date and time parameters are in UTC.

--- a/tests/unit/plugins/modules/test_storagebox_subaccount_info.py
+++ b/tests/unit/plugins/modules/test_storagebox_subaccount_info.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2025 Victor LEFEBVRE <dev@vic1707.xyz>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+from ansible_collections.community.internal_test_tools.tests.unit.utils.fetch_url_module_framework import (
+    FetchUrlCall,
+    BaseTestModule,
+)
+
+from ansible_collections.community.hrobot.plugins.module_utils.robot import BASE_URL
+from ansible_collections.community.hrobot.plugins.modules import (
+    storagebox_subaccount_info,
+)
+
+STORAGEBOX_SUBACCOUNTS = [
+    {
+        "subaccount": {
+            "username": "u2342-sub1",
+            "accountid": "u2342",
+            "server": "u12345-sub1.your-storagebox.de",
+            "homedirectory": "test",
+            "samba": True,
+            "ssh": True,
+            "external_reachability": True,
+            "webdav": False,
+            "readonly": False,
+            "createtime": "2017-05-24 00:00:00",
+            "comment": "Test account",
+        }
+    },
+    {
+        "subaccount": {
+            "username": "u2342-sub2",
+            "accountid": "u2342",
+            "server": "u12345-sub2.your-storagebox.de",
+            "homedirectory": "test2",
+            "samba": False,
+            "ssh": True,
+            "external_reachability": True,
+            "webdav": True,
+            "readonly": False,
+            "createtime": "2025-01-24 00:00:00",
+            "comment": "Test account 2",
+        }
+    },
+]
+
+
+class TestHetznerStorageboxSubbacountInfo(BaseTestModule):
+    MOCK_ANSIBLE_MODULEUTILS_BASIC_ANSIBLEMODULE = 'ansible_collections.community.hrobot.plugins.modules.storagebox_subaccount_info.AnsibleModule'
+    MOCK_ANSIBLE_MODULEUTILS_URLS_FETCH_URL = 'ansible_collections.community.hrobot.plugins.module_utils.robot.fetch_url'
+
+    def test_subaccounts(self, mocker):
+        result = self.run_module_success(mocker, storagebox_subaccount_info, {
+            'hetzner_user': 'test',
+            'hetzner_password': 'hunter2',
+            'storagebox_id': 23}, [
+            FetchUrlCall('GET', 200)
+            .expect_basic_auth('test', 'hunter2')
+            .expect_force_basic_auth(True)
+            .result_json(STORAGEBOX_SUBACCOUNTS)
+            .expect_url(BASE_URL + '/storagebox/23/subaccount')
+        ])
+        assert result['changed'] is False
+        assert len(result['subaccount']) == 2
+        assert result['subaccount'][0] == STORAGEBOX_SUBACCOUNTS[0]['subaccount']
+
+    def test_storagebox_id_unknown(self, mocker):
+        result = self.run_module_failed(mocker, storagebox_subaccount_info, {
+            'hetzner_user': '',
+            'hetzner_password': '',
+            'storagebox_id': 23
+        }, [
+            FetchUrlCall('GET', 404)
+            .result_json({
+                'error': {
+                    'status': 404,
+                    'code': 'STORAGEBOX_NOT_FOUND',
+                    'message': 'Storage Box with ID 23 does not exist',
+                }
+            })
+            .expect_url(BASE_URL + '/storagebox/23/subaccount')
+        ])
+        assert result['msg'] == 'Storagebox with ID 23 does not exist'

--- a/tests/unit/plugins/modules/test_storagebox_subaccount_info.py
+++ b/tests/unit/plugins/modules/test_storagebox_subaccount_info.py
@@ -67,8 +67,8 @@ class TestHetznerStorageboxSubbacountInfo(BaseTestModule):
             .expect_url(BASE_URL + '/storagebox/23/subaccount')
         ])
         assert result['changed'] is False
-        assert len(result['subaccount']) == 2
-        assert result['subaccount'][0] == STORAGEBOX_SUBACCOUNTS[0]['subaccount']
+        assert len(result['subaccounts']) == 2
+        assert result['subaccounts'][0] == STORAGEBOX_SUBACCOUNTS[0]['subaccount']
 
     def test_storagebox_id_unknown(self, mocker):
         result = self.run_module_failed(mocker, storagebox_subaccount_info, {


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Adds support for querying storagebox subaccounts.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`storagebox_subaccount_info`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
I want to do a bit more manual testing to ensure everything is correct, this is pretty much a 1:1 copy of `storagebox_snapshot_info` module.
