### PR TITLE
Inventory plugins: remove deprecated disable_lookups parameter (which was set to its default anyway)

### DIFF
--- a/changelogs/fragments/165--disable_lookups.yml
+++ b/changelogs/fragments/165--disable_lookups.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "robot inventory plugin - avoid using deprecated option when templating options (https://github.com/ansible-collections/community.hrobot/pull/165)."

--- a/plugins/module_utils/robot.py
+++ b/plugins/module_utils/robot.py
@@ -84,9 +84,9 @@ def raw_plugin_open_url_json(plugin, url, method='GET', timeout=10, data=None, h
     password = plugin.get_option('hetzner_password')
     if templar is not None:
         if templar.is_template(user):
-            user = templar.template(variable=user, disable_lookups=False)
+            user = templar.template(variable=user)
         if templar.is_template(password):
-            password = templar.template(variable=password, disable_lookups=False)
+            password = templar.template(variable=password)
     try:
         response = open_url(
             url,


### PR DESCRIPTION
##### SUMMARY
`Templar.template`'s parameter `disable_lookups` has been deprecated in ansible-core 2.19 (https://github.com/ansible/ansible/blob/34abc83822a4ee118cc813862ecdb8d2a6a1538b/lib/ansible/template/__init__.py#L273-L279). Inventory plugins have been using it (probably copied around from a common source), but they always set it to `False`, which happened to be the default since at least 2017 (I didn't bother to check back even more).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
inventory plugins
