### PR TITLE
ansible-core 2.20: avoid deprecated functionality

### DIFF
--- a/changelogs/fragments/174-deprecations.yml
+++ b/changelogs/fragments/174-deprecations.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Avoid deprecated functionality in ansible-core 2.20 (https://github.com/ansible-collections/community.hrobot/pull/174)."

--- a/plugins/plugin_utils/unsafe.py
+++ b/plugins/plugin_utils/unsafe.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 import re
 
 from ansible.module_utils.six import binary_type, text_type
-from ansible.module_utils.common._collections_compat import Mapping, Set
+from collections.abc import Mapping, Set
 from ansible.module_utils.common.collections import is_sequence
 from ansible.utils.unsafe_proxy import (
     AnsibleUnsafe,


### PR DESCRIPTION
##### SUMMARY
ansible.module_utils._text and ansible.module_utils.common._collections_compat have been deprecated.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
various
