### PR TITLE
Avoid six

### DIFF
--- a/changelogs/fragments/177-six.yml
+++ b/changelogs/fragments/177-six.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Avoid using ``ansible.module_utils.six`` to avoid deprecation warnings with ansible-core 2.20 (https://github.com/ansible-collections/community.hrobot/pull/177)."

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -7,10 +7,9 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+import sys
 
 from ansible.module_utils.common.text.converters import to_native
-from ansible.module_utils.six import PY3
-from ansible.module_utils.six.moves.urllib.parse import urlencode
 from ansible.module_utils.urls import fetch_url
 
 import time
@@ -18,6 +17,12 @@ import time
 from ansible_collections.community.hrobot.plugins.module_utils.common import (  # pylint: disable=unused-import
     CheckDoneTimeoutException,
 )
+
+try:
+    from urllib.parse import urlencode
+except ImportError:
+    # Python 2.x fallback:
+    from urllib import urlencode
 
 
 API_DEFAULT_ARGUMENT_SPEC = dict(
@@ -75,7 +80,7 @@ def raw_api_fetch_url_json(
     try:
         # In Python 2, reading from a closed response yields a TypeError.
         # In Python 3, read() simply returns ''
-        if PY3 and resp.closed:
+        if sys.version_info[0] > 2 and resp.closed:
             raise TypeError
         content = resp.read()
     except (AttributeError, TypeError):

--- a/plugins/module_utils/failover.py
+++ b/plugins/module_utils/failover.py
@@ -7,15 +7,18 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-
 import json
-
-from ansible.module_utils.six.moves.urllib.parse import urlencode
 
 from ansible_collections.community.hrobot.plugins.module_utils.robot import (
     BASE_URL,
     fetch_url_json,
 )
+
+try:
+    from urllib.parse import urlencode
+except ImportError:
+    # Python 2.x fallback:
+    from urllib import urlencode
 
 
 def get_failover_record(module, ip):

--- a/plugins/module_utils/robot.py
+++ b/plugins/module_utils/robot.py
@@ -7,9 +7,9 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+import sys
 
 from ansible.module_utils.common.text.converters import to_native
-from ansible.module_utils.six import PY3
 from ansible.module_utils.six.moves.urllib.error import HTTPError
 from ansible.module_utils.urls import fetch_url, open_url
 
@@ -151,7 +151,7 @@ def raw_fetch_url_json(module, url, method='GET', timeout=10, data=None, headers
     try:
         # In Python 2, reading from a closed response yields a TypeError.
         # In Python 3, read() simply returns ''
-        if PY3 and resp.closed:
+        if sys.version_info[0] > 2 and resp.closed:
             raise TypeError
         content = resp.read()
     except (AttributeError, TypeError):

--- a/plugins/modules/boot.py
+++ b/plugins/modules/boot.py
@@ -276,7 +276,6 @@ password:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six.moves.urllib.parse import urlencode
 
 from ansible_collections.community.hrobot.plugins.module_utils.robot import (
     BASE_URL,
@@ -288,6 +287,12 @@ from ansible_collections.community.hrobot.plugins.module_utils.ssh import (
     FingerprintError,
     extract_fingerprint,
 )
+
+try:
+    from urllib.parse import urlencode
+except ImportError:
+    # Python 2.x fallback:
+    from urllib import urlencode
 
 
 BOOT_CONFIGURATION_DATA = [

--- a/plugins/modules/firewall.py
+++ b/plugins/modules/firewall.py
@@ -442,7 +442,6 @@ from ansible_collections.community.hrobot.plugins.module_utils.robot import (
     fetch_url_json,
     fetch_url_json_with_retries,
 )
-from ansible.module_utils.six.moves.urllib.parse import urlencode
 from ansible.module_utils.common.text.converters import to_native, to_text
 
 try:
@@ -452,6 +451,12 @@ try:
 except ImportError as exc:
     IPADDRESS_IMP_ERR = traceback.format_exc()
     HAS_IPADDRESS = False
+
+try:
+    from urllib.parse import urlencode
+except ImportError:
+    # Python 2.x fallback:
+    from urllib import urlencode
 
 
 RULE_OPTION_NAMES = [

--- a/plugins/modules/reset.py
+++ b/plugins/modules/reset.py
@@ -91,13 +91,18 @@ EXAMPLES = r"""
 RETURN = r"""#"""
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six.moves.urllib.parse import urlencode
 
 from ansible_collections.community.hrobot.plugins.module_utils.robot import (
     BASE_URL,
     ROBOT_DEFAULT_ARGUMENT_SPEC,
     fetch_url_json,
 )
+
+try:
+    from urllib.parse import urlencode
+except ImportError:
+    # Python 2.x fallback:
+    from urllib import urlencode
 
 
 def main():

--- a/plugins/modules/reverse_dns.py
+++ b/plugins/modules/reverse_dns.py
@@ -76,13 +76,18 @@ EXAMPLES = r"""
 RETURN = r"""#"""
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six.moves.urllib.parse import urlencode
 
 from ansible_collections.community.hrobot.plugins.module_utils.robot import (
     BASE_URL,
     ROBOT_DEFAULT_ARGUMENT_SPEC,
     fetch_url_json,
 )
+
+try:
+    from urllib.parse import urlencode
+except ImportError:
+    # Python 2.x fallback:
+    from urllib import urlencode
 
 
 def main():

--- a/plugins/modules/server.py
+++ b/plugins/modules/server.py
@@ -212,13 +212,18 @@ server:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six.moves.urllib.parse import urlencode
 
 from ansible_collections.community.hrobot.plugins.module_utils.robot import (
     BASE_URL,
     ROBOT_DEFAULT_ARGUMENT_SPEC,
     fetch_url_json,
 )
+
+try:
+    from urllib.parse import urlencode
+except ImportError:
+    # Python 2.x fallback:
+    from urllib import urlencode
 
 
 def main():

--- a/plugins/modules/ssh_key.py
+++ b/plugins/modules/ssh_key.py
@@ -96,7 +96,6 @@ fingerprint:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
-from ansible.module_utils.six.moves.urllib.parse import urlencode
 
 from ansible_collections.community.hrobot.plugins.module_utils.robot import (
     BASE_URL,
@@ -110,6 +109,12 @@ from ansible_collections.community.hrobot.plugins.module_utils.ssh import (
     extract_fingerprint,
     remove_comment,
 )
+
+try:
+    from urllib.parse import urlencode
+except ImportError:
+    # Python 2.x fallback:
+    from urllib import urlencode
 
 
 def main():

--- a/plugins/modules/storagebox.py
+++ b/plugins/modules/storagebox.py
@@ -122,7 +122,6 @@ zfs:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
-from ansible.module_utils.six.moves.urllib.parse import urlencode
 
 from ansible_collections.community.hrobot.plugins.module_utils.robot import (
     BASE_URL,
@@ -139,6 +138,12 @@ from ansible_collections.community.hrobot.plugins.module_utils.api import (
     api_apply_action,
     api_fetch_url_json,
 )
+
+try:
+    from urllib.parse import urlencode
+except ImportError:
+    # Python 2.x fallback:
+    from urllib import urlencode
 
 
 PARAMETERS_LEGACY = {

--- a/plugins/modules/storagebox_info.py
+++ b/plugins/modules/storagebox_info.py
@@ -517,7 +517,6 @@ storageboxes:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six.moves.urllib.parse import urlencode
 
 from ansible_collections.community.hrobot.plugins.module_utils.robot import (
     BASE_URL,
@@ -533,6 +532,12 @@ from ansible_collections.community.hrobot.plugins.module_utils.api import (
     api_fetch_url_json,
     api_fetch_url_json_list,
 )
+
+try:
+    from urllib.parse import urlencode
+except ImportError:
+    # Python 2.x fallback:
+    from urllib import urlencode
 
 
 _CONVERT = {

--- a/plugins/modules/storagebox_set_password.py
+++ b/plugins/modules/storagebox_set_password.py
@@ -81,7 +81,6 @@ password:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six.moves.urllib.parse import urlencode
 
 from ansible_collections.community.hrobot.plugins.module_utils.robot import (
     BASE_URL,
@@ -97,6 +96,12 @@ from ansible_collections.community.hrobot.plugins.module_utils.api import (
     ApplyActionError,
     api_apply_action,
 )
+
+try:
+    from urllib.parse import urlencode
+except ImportError:
+    # Python 2.x fallback:
+    from urllib import urlencode
 
 
 def main():

--- a/plugins/modules/storagebox_snapshot.py
+++ b/plugins/modules/storagebox_snapshot.py
@@ -104,8 +104,6 @@ snapshot:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six.moves.urllib.parse import urlencode
-
 
 from ansible_collections.community.hrobot.plugins.module_utils.robot import (
     BASE_URL,
@@ -122,6 +120,12 @@ from ansible_collections.community.hrobot.plugins.module_utils.api import (
     api_apply_action,
     api_fetch_url_json,
 )
+
+try:
+    from urllib.parse import urlencode
+except ImportError:
+    # Python 2.x fallback:
+    from urllib import urlencode
 
 
 def legacy_handle_errors(module, error, storagebox_id=None, snapshot_name=None):

--- a/plugins/modules/storagebox_snapshot_plan.py
+++ b/plugins/modules/storagebox_snapshot_plan.py
@@ -167,7 +167,6 @@ plans:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six.moves.urllib.parse import urlencode
 
 from ansible_collections.community.hrobot.plugins.module_utils.robot import (
     BASE_URL,
@@ -184,6 +183,12 @@ from ansible_collections.community.hrobot.plugins.module_utils.api import (
     api_apply_action,
     api_fetch_url_json,
 )
+
+try:
+    from urllib.parse import urlencode
+except ImportError:
+    # Python 2.x fallback:
+    from urllib import urlencode
 
 
 LEGACY_PARAMETERS = {

--- a/plugins/modules/storagebox_subaccount.py
+++ b/plugins/modules/storagebox_subaccount.py
@@ -276,7 +276,6 @@ subaccount:
 
 from copy import deepcopy
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six.moves.urllib.parse import urlencode
 
 from ansible_collections.community.hrobot.plugins.module_utils.robot import (
     BASE_URL,
@@ -293,6 +292,12 @@ from ansible_collections.community.hrobot.plugins.module_utils.api import (
     api_apply_action,
     api_fetch_url_json,
 )
+
+try:
+    from urllib.parse import urlencode
+except ImportError:
+    # Python 2.x fallback:
+    from urllib import urlencode
 
 
 def legacy_encode_data(data):

--- a/plugins/modules/v_switch.py
+++ b/plugins/modules/v_switch.py
@@ -240,7 +240,6 @@ from datetime import datetime
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
-from ansible.module_utils.six.moves.urllib.parse import urlencode
 
 from ansible_collections.community.hrobot.plugins.module_utils.common import (
     CheckDoneTimeoutException,
@@ -252,6 +251,12 @@ from ansible_collections.community.hrobot.plugins.module_utils.robot import (
     fetch_url_json,
     fetch_url_json_with_retries,
 )
+
+try:
+    from urllib.parse import urlencode
+except ImportError:
+    # Python 2.x fallback:
+    from urllib import urlencode
 
 V_SWITCH_BASE_URL = '{0}/vswitch'.format(BASE_URL)
 

--- a/plugins/plugin_utils/unsafe.py
+++ b/plugins/plugin_utils/unsafe.py
@@ -6,14 +6,21 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import re
+import sys
 
-from ansible.module_utils.six import binary_type, text_type
 from collections.abc import Mapping, Set
 from ansible.module_utils.common.collections import is_sequence
 from ansible.utils.unsafe_proxy import (
     AnsibleUnsafe,
     wrap_var as _make_unsafe,
 )
+
+if sys.version_info[0] == 2:
+    binary_type = str
+    text_type = unicode  # noqa: F821, pylint: disable=undefined-variable
+else:
+    binary_type = bytes
+    text_type = str
 
 _RE_TEMPLATE_CHARS = re.compile(u'[{}]')
 _RE_TEMPLATE_CHARS_BYTES = re.compile(b'[{}]')

--- a/tests/sanity/ignore-2.20.txt
+++ b/tests/sanity/ignore-2.20.txt
@@ -1,4 +1,1 @@
-plugins/module_utils/api.py pylint:ansible-bad-import-from
-plugins/module_utils/robot.py pylint:ansible-bad-import-from
-plugins/plugin_utils/unsafe.py pylint:ansible-bad-import-from
 tests/ee/roles/smoke/library/smoke_ipaddress.py shebang


### PR DESCRIPTION
##### SUMMARY
ansible.module_utils.six is deprecated in ansible-core 2.20.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
various
