### PR TITLE
storagebox_subaccount: deprecate password_mode=set-to-random

### DIFF
--- a/changelogs/fragments/183-storagebox-depr.yml
+++ b/changelogs/fragments/183-storagebox-depr.yml
@@ -1,0 +1,4 @@
+deprecated_features:
+  - "storagebox_subaccount - ``password_mode=set-to-random`` is deprecated and will be removed from community.hrobot 3.0.0.
+     Hetzner's new API does not support this anyway, it can only be used with the legacy API
+     (https://github.com/ansible-collections/community.hrobot/pull/183)."

--- a/plugins/modules/storagebox_subaccount.py
+++ b/plugins/modules/storagebox_subaccount.py
@@ -57,6 +57,8 @@ options:
       - If C(update-if-provided), the password always updated if provided (default).
       - If C(ignore-if-exists), password is only used during creation.
       - If C(set-to-random), password is reset to a randomly generated one.
+        Note that this is not supported by the new API (when O(hetzner_token) is set).
+        The value has been deprecated in community.hrobot 2.7.0 and will be removed from community.hrobot 3.0.0.
       - When a new subaccount is created, the password is set to the specified one if O(password) is provided,
         and a random password is set if O(password) is not provided.
     type: str
@@ -688,6 +690,13 @@ def main():
         "comment": module.params["comment"],
     }
     account_identifier = subaccount[idempotence]
+
+    if password_mode == 'set-to-random':
+        module.deprecate(
+            "password_mode=set-to-random is deprecated and will be removed in community.hrobot 3.0.0.",
+            collection_name="community.hrobot",
+            version="3.0.0",
+        )
 
     if module.params["hetzner_user"] is not None:
         module.deprecate(


### PR DESCRIPTION
##### SUMMARY
This isn't supported by the new API anyway...

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
storagebox_subaccount
