### PR TITLE
Change warning to failure on firewall config timeout

### DIFF
--- a/plugins/modules/firewall.py
+++ b/plugins/modules/firewall.py
@@ -677,7 +677,7 @@ def main():
                 )
             except CheckDoneTimeoutException as e:
                 result, error = e.result, e.error
-                module.warn('Timeout while waiting for firewall to be configured.')
+                module.fail_json(msg='Timeout while waiting for firewall to be configured.')
 
         full_after = result['firewall']
         if not full_after.get('rules'):

--- a/tests/unit/plugins/modules/test_firewall.py
+++ b/tests/unit/plugins/modules/test_firewall.py
@@ -863,7 +863,7 @@ class TestHetznerFirewall(BaseTestModule):
 
     def test_wait_update_timeout(self, mocker):
         mocker.patch('time.sleep', lambda duration: None)
-        result = self.run_module_success(mocker, firewall, {
+        result = self.run_module_failed(mocker, firewall, {
             'hetzner_user': '',
             'hetzner_password': '',
             'server_ip': '1.2.3.4',

--- a/tests/unit/plugins/modules/test_firewall.py
+++ b/tests/unit/plugins/modules/test_firewall.py
@@ -929,7 +929,7 @@ class TestHetznerFirewall(BaseTestModule):
         assert result['firewall']['status'] == 'in process'
         assert result['firewall']['server_ip'] == '1.2.3.4'
         assert result['firewall']['server_number'] == 1
-        assert 'Timeout while waiting for firewall to be configured.' in extract_warnings_texts(result)
+        assert result['msg'] == 'Timeout while waiting for firewall to be configured.'
 
     def test_nowait_update(self, mocker):
         result = self.run_module_success(mocker, firewall, {

--- a/tests/unit/plugins/modules/test_firewall.py
+++ b/tests/unit/plugins/modules/test_firewall.py
@@ -920,12 +920,6 @@ class TestHetznerFirewall(BaseTestModule):
             })
             .expect_url('{0}/firewall/1.2.3.4'.format(BASE_URL)),
         ])
-        assert result['changed'] is True
-        assert result['diff']['before']['status'] == 'disabled'
-        assert result['diff']['after']['status'] == 'active'
-        assert result['firewall']['status'] == 'in process'
-        assert result['firewall']['server_ip'] == '1.2.3.4'
-        assert result['firewall']['server_number'] == 1
         assert result['msg'] == 'Timeout while waiting for firewall to be configured.'
 
     def test_nowait_update(self, mocker):

--- a/tests/unit/plugins/modules/test_firewall.py
+++ b/tests/unit/plugins/modules/test_firewall.py
@@ -8,9 +8,6 @@ __metaclass__ = type
 
 import pytest
 
-from ansible_collections.community.internal_test_tools.tests.unit.plugins.modules.utils import (
-    extract_warnings_texts,
-)
 from ansible_collections.community.internal_test_tools.tests.unit.utils.fetch_url_module_framework import (
     FetchUrlCall,
     BaseTestModule,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
To be consistent with other `module.fail_json` usage when updating the firewall times out.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
community.hrobot

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
There are 2 paths where a firewall timeout can happen. If a timeout occurs, the code should `fail` and not just `warn`.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
